### PR TITLE
fix(product): guard null image/stock arrays and persist image deletions on edit

### DIFF
--- a/src/components/product/Form/ProductFormModal.tsx
+++ b/src/components/product/Form/ProductFormModal.tsx
@@ -21,7 +21,7 @@ export interface ProductFormModalProps {
 	isOpen: boolean;
 	isSaving: boolean;
 	product?: Product | null;
-	onSave: (payload: ProductFormValues) => void;
+	onSave: (payload: ProductFormValues, imagesToRemove: number[]) => void;
 	onClose: () => void;
 }
 

--- a/src/components/product/Table/productsTableConfigs.tsx
+++ b/src/components/product/Table/productsTableConfigs.tsx
@@ -47,7 +47,7 @@ const Money = ({ value, archived }: { value: number | null; archived?: boolean }
  * primary-soft with the primary box icon. Archived rows fade it to 50%.
  */
 const ProductThumb = ({ product }: { product: Product }) => {
-	const image = product.images[0];
+	const image = product.images?.[0];
 	const src = image ? (getImageFullUrl(image.thumbnailUrl ?? image.originalUrl) ?? "") : null;
 
 	return (

--- a/src/hooks/product/useProductForm.ts
+++ b/src/hooks/product/useProductForm.ts
@@ -9,7 +9,7 @@ export interface UseProductFormOptions {
 	isOpen: boolean;
 	isSaving: boolean;
 	product?: Product | null;
-	onSave: (payload: ProductFormValues) => void;
+	onSave: (payload: ProductFormValues, imagesToRemove: number[]) => void;
 }
 
 export interface UseProductFormResult {
@@ -224,7 +224,10 @@ export const useProductForm = ({
 		}
 	}, [watchedType, setValue, clearErrors]);
 
-	const submit = handleSubmit(onSave);
+	// Thread the tracked image removals through to the save callback — RHF's
+	// handleSubmit only forwards validated form values, so the deletions
+	// (tracked outside the form) must be passed explicitly.
+	const submit = handleSubmit((values) => onSave(values, imagesToRemove));
 	// Save stays enabled (hard rule 5): validation runs on submit and reports
 	// inline; the button is only inert while a save is in flight.
 	const canSave = !isSaving;

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -65,7 +65,10 @@ const ProductDetailPage: React.FC = observer(() => {
 
 	// Edit/archive/restore only change product fields, never stock history —
 	// reflect the fresh product in place rather than refetching the ledgers.
-	const handleFormSave = async (payload: ProductFormValues): Promise<void> => {
+	const handleFormSave = async (
+		payload: ProductFormValues,
+		imagesToRemove: number[],
+	): Promise<void> => {
 		const request: CreateProductRequest = {
 			categoryId: payload.categoryId,
 			name: payload.name,
@@ -81,7 +84,11 @@ const ProductDetailPage: React.FC = observer(() => {
 			attachments: payload.attachments,
 		};
 
-		const updated = await productStore.update({ ...request, id: product.id, imagesToDelete: [] });
+		const updated = await productStore.update({
+			...request,
+			id: product.id,
+			imagesToDelete: imagesToRemove,
+		});
 		if (updated) {
 			selectedProductStore.applyProduct(updated);
 		}

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -30,7 +30,7 @@ const ProductPage: React.FC = observer(() => {
 	const dialogMode = productStore.dialogMode;
 	const editingProduct = dialogMode.kind === "form" ? (dialogMode.product ?? null) : null;
 
-	const handleFormSave = (payload: ProductFormValues): void => {
+	const handleFormSave = (payload: ProductFormValues, imagesToRemove: number[]): void => {
 		const request: CreateProductRequest = {
 			categoryId: payload.categoryId,
 			name: payload.name,
@@ -47,7 +47,7 @@ const ProductPage: React.FC = observer(() => {
 		};
 
 		if (editingProduct) {
-			productStore.update({ ...request, id: editingProduct.id, imagesToDelete: [] });
+			productStore.update({ ...request, id: editingProduct.id, imagesToDelete: imagesToRemove });
 		} else {
 			productStore.create(request);
 		}

--- a/src/utils/productUtils.ts
+++ b/src/utils/productUtils.ts
@@ -42,7 +42,10 @@ export function isAvialableForSale(product: Product) {
  * operands are served (hard rule 8); the backend may serve this directly later.
  */
 export function stockValue(product: Product): number {
-	return product.warehouseItems.reduce((sum, item) => sum + item.quantity * item.averageCost, 0);
+	return (product.warehouseItems ?? []).reduce(
+		(sum, item) => sum + item.quantity * item.averageCost,
+		0,
+	);
 }
 
 export function calculateLineTotals(unitPrice: number, quantity: number, discount: number) {


### PR DESCRIPTION
Frontend crash & data-integrity fixes from `issues-tracker.md` group **G1** (product module).

## Changes
- **Products list crash** — `product.images[0]` threw when the backend serves a null/absent `images` array; guarded with optional chaining. `productsTableConfigs.tsx` [S WEB-9]
- **Product detail crash** — `warehouseItems.reduce` threw on a null array; default to `[]` in `stockValue`. `productUtils.ts` [S WEB-8]
- **Edit dropped image deletions** — `imagesToDelete` was hardcoded to `[]`; the form's tracked `imagesToRemove` is now threaded through `onSave` into both the create and detail pages. [CR A-FE-2]

## Verification
`npm run validate` green. Live: products list renders with & without image thumbnails and a product detail renders, both with zero console errors. Image-deletion path is tsc-verified (live test requires a destructive edit — not run).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product image deletions are now applied when saving product changes.
* **Bug Fixes**
  * Prevented errors when products have no images.
  * Prevented stock value calculations from failing when warehouse inventory is unavailable.
  * Preserved image deletion details throughout the product save process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
