### PR TITLE
fix(integrity): correct refund cap, guard stale loads, CSV injection, JWT UTF-8

### DIFF
--- a/src/components/transaction/Refund/RefundModal.tsx
+++ b/src/components/transaction/Refund/RefundModal.tsx
@@ -78,7 +78,7 @@ const RefundModal: React.FC<RefundModalProps> = ({
 					(sum, r) =>
 						sum +
 						r.lines
-							.filter((rl) => rl.productName === l.productName)
+							.filter((rl) => rl.productId === l.productId)
 							.reduce((s, rl) => s + rl.quantity, 0),
 					0,
 				);

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -30,6 +30,18 @@ const CLAIM_PHONE = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/mobil
 const CLAIM_ID = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
 
 /**
+ * Decode a JWT payload segment as UTF-8. `atob` yields a Latin-1 (binary)
+ * string, so multi-byte UTF-8 claims (e.g. Cyrillic display names) must be
+ * re-decoded from the raw bytes before `JSON.parse`, otherwise the name
+ * arrives as mojibake.
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+	const segment = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+	const bytes = Uint8Array.from(atob(segment), (c) => c.charCodeAt(0));
+	return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+/**
  * The backend exposes no /me endpoint yet — the access token's claims are
  * the only source of user identity (display name, phone, id). The tenant
  * name is not in the token; `organizationName` stays unset until the
@@ -37,15 +49,15 @@ const CLAIM_ID = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameiden
  */
 function userFromAccessToken(token: string): AuthUser | null {
 	try {
-		const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
-		const fullName: string = payload[CLAIM_NAME] ?? "";
+		const payload = decodeJwtPayload(token);
+		const fullName = (payload[CLAIM_NAME] as string | undefined) ?? "";
 		const [firstName, ...rest] = fullName.split(" ").filter(Boolean);
 
 		return {
 			id: payload[CLAIM_ID] ? Number(payload[CLAIM_ID]) : undefined,
 			firstName,
 			lastName: rest.length > 0 ? rest.join(" ") : undefined,
-			phoneNumber: payload[CLAIM_PHONE],
+			phoneNumber: payload[CLAIM_PHONE] as string | undefined,
 		};
 	} catch {
 		return null;

--- a/src/stores/DashboardStore.ts
+++ b/src/stores/DashboardStore.ts
@@ -33,15 +33,25 @@ export class DashboardStore implements IDashboardStore {
 	isLoading = false;
 	period: DashboardPeriod = "month";
 
+	/** Monotonic load counter — guards against a slow response overwriting a newer one. */
+	private loadSeq = 0;
+
 	constructor(notificationStore: NotificationStore) {
 		this.notificationStore = notificationStore;
 		makeAutoObservable(this, {}, { autoBind: true });
 	}
 
 	async load(): Promise<void> {
+		const seq = ++this.loadSeq;
 		runInAction(() => (this.isLoading = true));
 
 		const result = await tryRun(() => DashboardApi.get(this.period));
+
+		// A newer load started while this was in flight — discard this response so a
+		// slow earlier-period fetch can't clobber the current period's KPIs.
+		if (seq !== this.loadSeq) {
+			return;
+		}
 
 		if (result.status === "fail") {
 			this.notificationStore.error(i18next.t("dashboard.error.load"));

--- a/src/stores/PartnerLedgerStore.ts
+++ b/src/stores/PartnerLedgerStore.ts
@@ -29,12 +29,16 @@ export class PartnerLedgerStore implements IPartnerLedgerStore {
 	partner: Loadable<Partner | null> = "loading";
 	ledger: Loadable<PartnerLedgerEntry[]> = "loading";
 
+	/** Monotonic load counter — guards against partner A's response landing on partner B's page. */
+	private loadSeq = 0;
+
 	constructor(notificationStore: NotificationStore) {
 		this.notificationStore = notificationStore;
 		makeAutoObservable(this, {}, { autoBind: true });
 	}
 
 	async load(partnerId: number): Promise<void> {
+		const seq = ++this.loadSeq;
 		runInAction(() => {
 			this.partner = "loading";
 			this.ledger = "loading";
@@ -44,6 +48,12 @@ export class PartnerLedgerStore implements IPartnerLedgerStore {
 			tryRun(() => PartnerApi.getById(partnerId)),
 			tryRun(() => PartnerApi.getLedger(partnerId)),
 		]);
+
+		// Superseded by a newer load (navigated to another partner) — drop this
+		// response so partner A's ledger can't render on partner B's page.
+		if (seq !== this.loadSeq) {
+			return;
+		}
 
 		if (partner.status === "fail") {
 			this.notificationStore.error(i18next.t("partner.error.getById"));
@@ -62,6 +72,8 @@ export class PartnerLedgerStore implements IPartnerLedgerStore {
 	}
 
 	clear(): void {
+		// Invalidate any in-flight load so a late response can't repopulate after unmount.
+		this.loadSeq++;
 		this.partner = "loading";
 		this.ledger = "loading";
 	}

--- a/src/utils/exportToCsv.ts
+++ b/src/utils/exportToCsv.ts
@@ -21,11 +21,15 @@ const BOM = String.fromCharCode(0xfeff);
 
 function escapeCell(raw: string | number | null | undefined): string {
 	const value = raw == null ? "" : String(raw);
+	// Neutralise CSV formula injection: a leading =, +, -, @ (or tab/CR) makes
+	// Excel/Sheets evaluate the cell as a formula. Prefix an apostrophe so the
+	// spreadsheet treats it as literal text (OWASP CSV Injection).
+	const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 	// Quote when the value contains the delimiter, a quote, or a newline.
-	if (/[";\r\n]/.test(value)) {
-		return `"${value.replace(/"/g, '""')}"`;
+	if (/[";\r\n]/.test(guarded)) {
+		return `"${guarded.replace(/"/g, '""')}"`;
 	}
-	return value;
+	return guarded;
 }
 
 /**


### PR DESCRIPTION
Cross-cutting correctness/security fixes from `issues-tracker.md` group **G1**.

## Changes
- **Refund cap** — summed prior refunds by product *name*, corrupting the rule-5 limit when names collide/change; now matches by `productId`. `RefundModal.tsx` [CR A-FE-4]
- **Stale-response overwrite** — `DashboardStore` / `PartnerLedgerStore` could commit a superseded response (wrong-period KPIs; partner A's ledger on partner B's page). Added a monotonic `loadSeq` guard that drops stale responses. [CR A-FE-5]
- **CSV formula injection** — cells beginning with `= + - @` (or tab/CR) are now prefixed with `'` so spreadsheets treat them as text. `exportToCsv.ts` [CR A-FE-3]
- **JWT Cyrillic mojibake** — payload decoded via `atob` mangled multi-byte UTF-8 (Cyrillic names); decode the bytes through `TextDecoder` before `JSON.parse`. `AuthStore.ts` [CR A-FE-6]

## Verification
`npm run validate` green. Live: JWT fix proven deterministically in-browser (old `atob`→mojibake, new→correct Cyrillic); dashboard + partner ledger load fine (guard doesn't regress). Refund cap and CSV are pure-logic changes, tsc-verified.
