### PR TITLE
fix(telemetry): stop reporting client-caused 4xx to Sentry

### DIFF
--- a/src/services/api/httpErrorInterceptor.ts
+++ b/src/services/api/httpErrorInterceptor.ts
@@ -39,17 +39,12 @@ export function attachHttpErrorInterceptors(instance: AxiosInstance): void {
 					extra: { url },
 				});
 			} else {
-				// A 4xx means the server answered — it's up.
+				// A 4xx means the server answered — it's up. Client-caused 4xx
+				// (validation, not-found, conflict, auth) are user errors surfaced
+				// inline in the UI, not defects — they must not create Sentry events
+				// (the FE analog of the backend's BeforeSend filter). 5xx/network
+				// still report above; a beforeSend hook drops any 4xx as a backstop.
 				ConnectivityBridge.reportUp();
-				// Capture handled 4xx for visibility, but skip 401s: those are auth
-				// flow (incl. the expected bootstrap refresh 401) and just noise.
-				if (status !== 401) {
-					Sentry.captureException(err, {
-						level: "warning",
-						tags: { httpStatus: status, httpMethod: method },
-						extra: { url },
-					});
-				}
 			}
 
 			return Promise.reject(err);

--- a/src/services/telemetry/sentry.ts
+++ b/src/services/telemetry/sentry.ts
@@ -7,6 +7,7 @@ import {
 	useNavigationType,
 } from "react-router-dom";
 import * as Sentry from "@sentry/react";
+import { isAxiosError } from "axios";
 
 let initialized = false;
 
@@ -31,6 +32,22 @@ export function initSentry(): void {
 		dsn,
 		environment: import.meta.env.VITE_OMBOR_ENVIRONMENT ?? import.meta.env.MODE,
 		release: __APP_RELEASE__,
+		// Drop client-caused 4xx (validation / not-found / conflict / auth):
+		// these are user errors surfaced inline in the UI, not defects — the FE
+		// analog of the backend's exception filter. 5xx and network errors still
+		// report. Global backstop for the interceptor's own 4xx suppression.
+		beforeSend(event, hint) {
+			const error = hint?.originalException;
+			if (
+				isAxiosError(error) &&
+				error.response &&
+				error.response.status >= 400 &&
+				error.response.status < 500
+			) {
+				return null;
+			}
+			return event;
+		},
 		// Beta max-capture (plan decision #2); revisit before GA.
 		sendDefaultPii: true,
 		integrations: [


### PR DESCRIPTION
Frontend analog of `issues-tracker.md` group **G5** Sentry-noise policy.

## Changes
- `httpErrorInterceptor` previously captured every 4xx (except 401) as a Sentry warning — i.e. user-caused client errors. It no longer reports 4xx (5xx and network failures still report; `ConnectivityBridge.reportUp()` retained).
- Added a global `beforeSend` backstop in the Sentry config that drops any `AxiosError` with a 4xx status, catching 4xx reported from other call sites too.

## Verification
`npm run validate` green. Sentry is DSN-gated **off** in local dev, so no events fire to observe live — this is code-verified. The BE half of the noise policy remains open in G5.
