### PR TITLE
fix(forms): teach ProductType inline, validate Telegram handle, normalize language header

### DIFF
--- a/src/components/product/Form/Fields/ProductCoreFields.tsx
+++ b/src/components/product/Form/Fields/ProductCoreFields.tsx
@@ -9,7 +9,15 @@ import { ProductType } from "models/product";
 import { ProductFormInputs } from "schemas/ProductSchema";
 
 import AutorenewIcon from "@mui/icons-material/Autorenew";
-import { Box, IconButton, InputAdornment, MenuItem, Stack, TextField } from "@mui/material";
+import {
+	Box,
+	IconButton,
+	InputAdornment,
+	MenuItem,
+	Stack,
+	TextField,
+	Typography,
+} from "@mui/material";
 
 export interface ProductFormCoreFieldsProps {
 	control: Control<ProductFormInputs>;
@@ -217,6 +225,11 @@ const ProductFormCoreFields: React.FC<ProductFormCoreFieldsProps> = ({
 							/>
 						)}
 					/>
+					{/* Explain the chosen type — new users don't know that "Закупка" hides
+					    a product from the sales POS. Teach it inline. */}
+					<Typography sx={{ fontSize: 12, color: "text.secondary", lineHeight: 1.45 }}>
+						{t(`product.form.typeHint.${type}`)}
+					</Typography>
 				</Stack>
 			</Box>
 

--- a/src/i18n/ru/partner.json
+++ b/src/i18n/ru/partner.json
@@ -219,6 +219,7 @@
   "partner.validation.companyNameTooLong": "Название компании не должно превышать 100 символов",
   "partner.validation.addressTooLong": "Адрес не должен превышать 200 символов",
   "partner.validation.telegramTooLong": "Telegram не должен превышать 100 символов",
+  "partner.validation.telegramInvalid": "Введите корректный логин, например @shop_name",
   "partner.validation.invalidEmail": "Некорректный формат почты",
   "partner.validation.phoneRequired": "Укажите хотя бы один номер телефона",
   "partner.validation.phoneNumbersInvalid": "Телефон должен содержать только цифры (опционально «+») и иметь 7-15 символов",

--- a/src/i18n/ru/product.json
+++ b/src/i18n/ru/product.json
@@ -140,6 +140,9 @@
   "product.type.All": "Оба",
   "product.type.Sale": "Продажа",
   "product.type.Supply": "Закупка",
+  "product.form.typeHint.Sale": "Этот товар будет доступен только для продаж.",
+  "product.form.typeHint.Supply": "Этот товар будет доступен только для закупок.",
+  "product.form.typeHint.All": "Этот товар будет доступен и для продаж, и для закупок.",
 
   "product.packaging": "Фасовка",
   "product.packaging.size": "Размер упаковки",

--- a/src/schemas/PartnerSchema.ts
+++ b/src/schemas/PartnerSchema.ts
@@ -28,6 +28,10 @@ const optionalTrimmed = (max: number, key: string) =>
 
 const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,63}$/;
 
+// Telegram handle: optional leading @, must start with a letter, then
+// letters/digits/underscore, 5–32 chars total (Telegram's own rule).
+const telegramRegex = /^@?[A-Za-z][A-Za-z0-9_]{4,31}$/;
+
 export const PartnerSchema = z.object({
 	type: PartnerTypeSchema,
 
@@ -41,7 +45,15 @@ export const PartnerSchema = z.object({
 
 	address: optionalTrimmed(200, "partner.validation.addressTooLong"),
 
-	telegram: optionalTrimmed(100, "partner.validation.telegramTooLong"),
+	telegram: z
+		.string()
+		.trim()
+		.max(100, i18next.t("partner.validation.telegramTooLong"))
+		.refine((v) => v === "" || telegramRegex.test(v), {
+			message: i18next.t("partner.validation.telegramInvalid"),
+		})
+		.transform((v) => (v === "" ? undefined : v))
+		.optional(),
 
 	email: z
 		.string()

--- a/src/services/api/AuthApi.ts
+++ b/src/services/api/AuthApi.ts
@@ -25,7 +25,12 @@ const AUTH_BASE = "/api/auth" as const;
  * follows the user's selection as more languages land. `resolvedLanguage`
  * accounts for the fallback; defaults to `ru`.
  */
-const activeLanguage = (): string => i18n.resolvedLanguage ?? i18n.language ?? "ru";
+const activeLanguage = (): string => {
+	const lng = i18n.resolvedLanguage ?? i18n.language ?? "ru";
+	// The backend validates against {ru, uz-Latn, uz-Cyrl}; the app's `uz` locale
+	// must be sent as `uz-Latn` (ru / uz-Cyrl already match).
+	return lng === "uz" ? "uz-Latn" : lng;
+};
 
 /**
  * Axios request config carrying the active UI language via the `X-Ombor-Language`


### PR DESCRIPTION
Three small clarity/correctness fixes from the ratified tracker decisions.

## Changes
- **ProductType helper text** — newly-registered users don't know that "Закупка" (Supply) hides a product from the sales POS. A dynamic caption under the type selector now explains what the selected type does (Sale / Supply / All). `ProductCoreFields.tsx`
- **Telegram handle validation** — the partner Telegram field was length-only; it now validates the handle format when provided (optional `@`, 5–32 chars, Telegram's rule). `PartnerSchema.ts`
- **Language header** — send the backend's expected `uz-Latn` for the app's `uz` locale in `X-Ombor-Language` (`ru`/`uz-Cyrl` already match). `AuthApi.ts`

## Verification
`npm run validate` green. Live verification pending (ProductType helper + Telegram inline error) against a running session.