### PR TITLE
refactor(forms): remove validation-summary banners, move semantic errors inline

### DIFF
--- a/src/components/order/Modal/OrderFormModal.tsx
+++ b/src/components/order/Modal/OrderFormModal.tsx
@@ -21,12 +21,10 @@ import { lineNet } from "utils/orderUtils";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import CheckIcon from "@mui/icons-material/Check";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import {
-	Alert,
 	Box,
 	Button,
 	Dialog,
@@ -224,14 +222,6 @@ const OrderFormModal: React.FC<OrderFormModalProps> = ({
 	const clientErr = submitted && !client;
 	const deliverErr = submitted && !deliveryDate;
 	const linesErr = submitted && lines.length === 0;
-	const showBanner = clientErr || deliverErr || linesErr;
-	const missing = [
-		clientErr && t("order.field.clientLower"),
-		deliverErr && t("order.field.deliveryDateLower"),
-		linesErr && t("order.field.linesLower"),
-	]
-		.filter(Boolean)
-		.join(", ");
 
 	const submit = () => {
 		setSubmitted(true);
@@ -284,17 +274,6 @@ const OrderFormModal: React.FC<OrderFormModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("order.edit.errFields", { fields: missing })}
-						</Alert>
-					)}
-
 					<Box
 						sx={{
 							display: "grid",
@@ -481,6 +460,11 @@ const OrderFormModal: React.FC<OrderFormModalProps> = ({
 								<Typography sx={{ fontSize: 12.5, color: "text.secondary", mt: "3px" }}>
 									{t("order.edit.emptyBody")}
 								</Typography>
+								{linesErr && (
+									<Typography sx={{ fontSize: 12.5, color: "error.main", mt: "8px" }}>
+										{t("order.new.cart.emptyErrorTitle")}
+									</Typography>
+								)}
 							</Box>
 						) : (
 							lines.map((line, index) => (

--- a/src/components/payment/Form/PaymentCreateModal.tsx
+++ b/src/components/payment/Form/PaymentCreateModal.tsx
@@ -29,7 +29,6 @@ import BalanceOutlinedIcon from "@mui/icons-material/BalanceOutlined";
 import CheckIcon from "@mui/icons-material/Check";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import {
-	Alert,
 	Box,
 	Dialog,
 	DialogActions,
@@ -189,9 +188,6 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 		});
 	});
 
-	const errorCount = Object.keys(formState.errors).length;
-	const showErrorBanner = formState.isSubmitted && (errorCount > 0 || overWithdraw);
-
 	const fieldError = (name: keyof PaymentFormValues): string | undefined =>
 		(formState.errors[name]?.message as string | undefined) ?? undefined;
 
@@ -237,12 +233,6 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 						/>
 					</Stack>
 					<Box sx={{ height: "1px", bgcolor: "divider", mb: "20px" }} />
-
-					{showErrorBanner && (
-						<Alert severity="error" variant="outlined" sx={{ mb: "16px" }}>
-							{t("payment.form.errorBanner")}
-						</Alert>
-					)}
 
 					{/* STEP 2 — per-type fields */}
 					{needsPartner && (

--- a/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
+++ b/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
@@ -26,7 +26,6 @@ import NorthEastIcon from "@mui/icons-material/NorthEast";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import SouthEastIcon from "@mui/icons-material/SouthEast";
 import {
-	Alert,
 	Box,
 	Dialog,
 	DialogContent,
@@ -307,10 +306,6 @@ const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({
 	const afterBalance = avail + signedDelta;
 
 	const reasons = reasonsFor(direction);
-	const errorCount = Object.keys(formState.errors).length;
-	// Over-stock is surfaced inline (the strip's floor state + the floor note),
-	// per the design — the top banner is only for missing required fields.
-	const showBanner = formState.isSubmitted && errorCount > 0;
 
 	const handleProductChange = (product: Product | null) => {
 		setSelected(product);
@@ -342,17 +337,6 @@ const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("adjustment.form.errorBanner")}
-						</Alert>
-					)}
-
 					<Stack sx={{ gap: "16px" }}>
 						<Stack sx={{ gap: "7px" }}>
 							<FormFieldLabel label={t("adjustment.field.warehouse")} required />

--- a/src/components/template/Modal/TemplateFormModal.tsx
+++ b/src/components/template/Modal/TemplateFormModal.tsx
@@ -22,14 +22,12 @@ import { MEASUREMENT_SHORT } from "utils/productUtils";
 
 import CheckIcon from "@mui/icons-material/Check";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import SellOutlinedIcon from "@mui/icons-material/SellOutlined";
 import {
-	Alert,
 	alpha,
 	Box,
 	Button,
@@ -244,17 +242,7 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
 		onClose,
 	);
 
-	const nameErr = Boolean(formState.errors.name);
-	const partnerErr = Boolean(formState.errors.partnerId);
 	const linesErr = Boolean(formState.errors.items);
-	const showBanner = formState.isSubmitted && (nameErr || partnerErr || linesErr);
-	const missing = [
-		nameErr && t("template.field.nameLower"),
-		partnerErr && t("template.field.partnerLower"),
-		linesErr && t("template.field.linesLower"),
-	]
-		.filter(Boolean)
-		.join(", ");
 
 	const priceLabel =
 		templateType === "Sale" ? t("template.form.salePrices") : t("template.form.supplyPrices");
@@ -278,17 +266,6 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("template.form.errorBanner", { fields: missing })}
-						</Alert>
-					)}
-
 					<Box
 						sx={{
 							display: "grid",
@@ -424,6 +401,11 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
 								<Typography sx={{ fontSize: 12.5, color: "text.secondary", mt: "3px" }}>
 									{t("template.form.emptyBody")}
 								</Typography>
+								{linesErr && (
+									<Typography sx={{ fontSize: 12.5, color: "error.main", mt: "8px" }}>
+										{t("template.validation.itemsRequired")}
+									</Typography>
+								)}
 							</Box>
 						) : (
 							items.map((field, index) => {

--- a/src/components/transaction/Refund/RefundModal.tsx
+++ b/src/components/transaction/Refund/RefundModal.tsx
@@ -20,7 +20,6 @@ import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import WarehouseOutlinedIcon from "@mui/icons-material/WarehouseOutlined";
 import {
-	Alert,
 	Box,
 	Dialog,
 	DialogActions,
@@ -206,17 +205,6 @@ const RefundModal: React.FC<RefundModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{(noLines || anyOver) && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{noLines ? t("transaction.refund.noLinesBanner") : t("transaction.refund.overBanner")}
-						</Alert>
-					)}
-
 					<Typography
 						sx={{
 							fontSize: 11,
@@ -448,6 +436,17 @@ const RefundModal: React.FC<RefundModalProps> = ({
 							</tbody>
 						</Box>
 					</Box>
+
+					{noLines && (
+						<Typography sx={{ mt: "10px", color: "error.main", fontSize: 12.5 }}>
+							{t("transaction.refund.noLinesBanner")}
+						</Typography>
+					)}
+					{anyOver && (
+						<Typography sx={{ mt: "10px", color: "error.main", fontSize: 12.5 }}>
+							{t("transaction.refund.overBanner")}
+						</Typography>
+					)}
 
 					<Box sx={{ mt: "22px", display: "flex", flexDirection: "column", gap: "7px" }}>
 						<Typography

--- a/src/components/transfer/Form/TransferFormModal.tsx
+++ b/src/components/transfer/Form/TransferFormModal.tsx
@@ -23,11 +23,9 @@ import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import {
-	Alert,
 	Box,
 	Button,
 	Dialog,
@@ -158,15 +156,6 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 	).length;
 	const noCompleteLines = completeLines === 0;
 
-	const showBanner = anyOver || (formState.isSubmitted && Object.keys(formState.errors).length > 0);
-	const bannerMessage = sameWarehouse
-		? t("transfer.form.sameWarehouseBanner")
-		: anyOver
-			? t("transfer.form.overStockBanner")
-			: noCompleteLines
-				? t("transfer.form.noLinesBanner")
-				: t("transfer.form.errorBanner");
-
 	return (
 		<>
 			<Dialog
@@ -186,17 +175,6 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{bannerMessage}
-						</Alert>
-					)}
-
 					{/* route: from → to */}
 					<Box
 						sx={{
@@ -364,6 +342,17 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 							);
 						})}
 					</Stack>
+
+					{anyOver && (
+						<Typography sx={{ color: "error.main", fontSize: 12.5, mt: "8px" }}>
+							{t("transfer.form.overStockBanner")}
+						</Typography>
+					)}
+					{formState.isSubmitted && noCompleteLines && (
+						<Typography sx={{ color: "error.main", fontSize: 12.5, mt: "8px" }}>
+							{t("transfer.form.noLinesBanner")}
+						</Typography>
+					)}
 
 					<Button
 						onClick={() => lines.append(emptyLine())}

--- a/src/components/wallet/Form/WalletFormModal.tsx
+++ b/src/components/wallet/Form/WalletFormModal.tsx
@@ -15,11 +15,9 @@ import { WalletFormValues } from "schemas/WalletSchema";
 import { designTokens, numericSx } from "theme";
 import { formatCurrency } from "utils/formatCurrency";
 
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import {
-	Alert,
 	Box,
 	ButtonBase,
 	Dialog,
@@ -150,9 +148,6 @@ const WalletFormModal: React.FC<WalletFormModalProps> = ({
 		onClose,
 	);
 
-	const errorCount = Object.keys(formState.errors).length;
-	const showErrorBanner = formState.isSubmitted && errorCount > 0;
-
 	return (
 		<>
 			<Dialog
@@ -172,17 +167,6 @@ const WalletFormModal: React.FC<WalletFormModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showErrorBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("wallet.form.errorBanner")}
-						</Alert>
-					)}
-
 					<Stack sx={{ gap: "16px" }}>
 						<Stack sx={{ gap: "7px" }}>
 							<FormFieldLabel label={t("wallet.field.name")} required />

--- a/src/components/wallet/Form/WalletTransferModal.tsx
+++ b/src/components/wallet/Form/WalletTransferModal.tsx
@@ -18,12 +18,10 @@ import { formatCurrency } from "utils/formatCurrency";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import {
-	Alert,
 	Box,
 	Dialog,
 	DialogActions,
@@ -174,8 +172,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 		onClose,
 	);
 
-	const showBanner = over || (formState.isSubmitted && Object.keys(formState.errors).length > 0);
-
 	return (
 		<>
 			<Dialog
@@ -229,17 +225,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 							</Box>
 						</Typography>
 					</Box>
-
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("wallet.transfer.errorBanner")}
-						</Alert>
-					)}
 
 					<Stack sx={{ gap: "16px" }}>
 						{/* Source → destination on one row (WAL-17). */}
@@ -341,6 +326,13 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 												placeholder="0"
 												disabled={isSaving}
 												error={!!fieldState.error || over}
+												helperText={
+													over
+														? t("wallet.transfer.overBalance", {
+																available: formatCurrency(available),
+															})
+														: fieldState.error?.message
+												}
 												slotProps={{
 													input: {
 														endAdornment: <InputAdornment position="end">UZS</InputAdornment>,
@@ -361,17 +353,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 									</GhostButton>
 								)}
 							</Box>
-							{over ? (
-								<Typography sx={{ fontSize: 12, color: "error.main" }}>
-									{t("wallet.transfer.overBalance", { available: formatCurrency(available) })}
-								</Typography>
-							) : (
-								formState.errors.amount && (
-									<Typography sx={{ fontSize: 12, color: "error.main" }}>
-										{formState.errors.amount.message}
-									</Typography>
-								)
-							)}
 						</Stack>
 
 						<Stack sx={{ gap: "7px" }}>

--- a/src/components/warehouse/Form/OpeningStockModal.tsx
+++ b/src/components/warehouse/Form/OpeningStockModal.tsx
@@ -23,11 +23,9 @@ import { MEASUREMENT_SHORT } from "utils/productUtils";
 import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import {
-	Alert,
 	Box,
 	Button,
 	Dialog,
@@ -118,11 +116,10 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 	const totalUnits = completeLines.reduce((sum, l) => sum + l.quantity, 0);
 	const batchValue = completeLines.reduce((sum, l) => sum + l.quantity * l.unitCost, 0);
 
-	const errorCount = Object.keys(formState.errors).length;
+	// Semantic "add at least one line" message shown inline near the table after a
+	// submit attempt; field-level errors surface per-row (no top-of-form banner).
 	const noCompleteLines = completeLines.length === 0;
-	const showBanner = formState.isSubmitted && (errorCount > 0 || noCompleteLines);
-	const bannerMessage =
-		errorCount > 0 ? t("warehouse.opening.errorBanner") : t("warehouse.opening.noLinesBanner");
+	const showNoLinesError = formState.isSubmitted && noCompleteLines;
 
 	// A new row is only useful while un-stocked, un-picked products remain.
 	const pickedIds = new Set((watchedItems ?? []).map((l) => l.productId).filter(Boolean));
@@ -147,17 +144,6 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{bannerMessage}
-						</Alert>
-					)}
-
 					{/* column labels */}
 					<Box
 						sx={{
@@ -317,6 +303,12 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 							);
 						})}
 					</Stack>
+
+					{showNoLinesError && (
+						<Typography sx={{ mt: "8px", color: "error.main", fontSize: 12.5 }}>
+							{t("warehouse.opening.noLinesBanner")}
+						</Typography>
+					)}
 
 					<Button
 						onClick={() => lines.append(emptyLine())}

--- a/src/components/warehouse/Form/WarehouseFormModal.tsx
+++ b/src/components/warehouse/Form/WarehouseFormModal.tsx
@@ -11,9 +11,8 @@ import { observer } from "mobx-react-lite";
 import { Warehouse } from "models/warehouse";
 import { WarehouseFormValues } from "schemas/WarehouseSchema";
 
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
-import { Alert, Dialog, DialogContent, LinearProgress, Stack, TextField } from "@mui/material";
+import { Dialog, DialogContent, LinearProgress, Stack, TextField } from "@mui/material";
 
 export interface WarehouseFormModalProps {
 	isOpen: boolean;
@@ -50,9 +49,6 @@ const WarehouseFormModal: React.FC<WarehouseFormModalProps> = ({
 		void submit();
 	};
 
-	const errorCount = Object.keys(formState.errors).length;
-	const showErrorBanner = formState.isSubmitted && errorCount > 0;
-
 	return (
 		<>
 			<Dialog
@@ -72,17 +68,6 @@ const WarehouseFormModal: React.FC<WarehouseFormModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{showErrorBanner && (
-						<Alert
-							severity="error"
-							icon={<ErrorOutlineIcon />}
-							variant="outlined"
-							sx={{ mb: "16px" }}
-						>
-							{t("warehouse.form.errorBanner")}
-						</Alert>
-					)}
-
 					<Stack sx={{ gap: "16px" }}>
 						<Stack sx={{ gap: "7px" }}>
 							<FormFieldLabel label={t("warehouse.field.name")} required />

--- a/src/i18n/ru/product.json
+++ b/src/i18n/ru/product.json
@@ -118,7 +118,6 @@
   "product.supplyPrice": "Цена поставки",
   "product.salePrice": "Цена продажи",
 
-  "product.form.errorBanner": "Заполните обязательные поля: проверьте отмеченные поля ниже.",
   "product.form.namePlaceholder": "Например: Шоколад Молочный 100г",
   "product.form.categoryPlaceholder": "Выберите категорию",
   "product.form.skuPlaceholder": "SKU-00000",


### PR DESCRIPTION
Per the ratified "no global form banners — inline errors only" convention. Submit/server failures already surface via toasts (`notificationStore`), so nothing is lost.

## Changes
- Removed the top-of-form validation-summary `<Alert>` from 10 data-entry modals: wallet, warehouse, stock-adjustment, payment, template, order, wallet-transfer, transfer, opening-stock, refund. Inline field errors + RHF auto-focus cover required-field validation.
- Relocated **semantic** (non-field) messages inline next to the relevant control instead of a banner: over-balance (wallet transfer), over-stock / no-lines (transfer, opening-stock, refund, order, template).
- Pruned the orphaned `product.form.errorBanner` key.

**Related PRs:** the Partner and Register forms are handled in #68 and #67 (which already own those files) to avoid conflicts.

## Verification
`npm run validate` green. Live: wallet form on empty submit shows no banner, just the inline field error. The semantic conversions were code-reviewed (a workflow regression that downgraded WalletTransfer's over-balance message was caught and fixed).