### PR TITLE
feat(wallet): hard-block wallet outflows that exceed the balance

### DIFF
--- a/src/components/payment/Form/PaymentCreateModal.tsx
+++ b/src/components/payment/Form/PaymentCreateModal.tsx
@@ -131,6 +131,13 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 
 	const overWithdraw = type === "Withdrawal" && partner != null && amount > partner.advance;
 
+	// Block a wallet outflow (Expense direction) that exceeds the source wallet's
+	// balance — mirrors the transfer over-balance guard. Enforced here, not in the
+	// schema (the balance is contextual). Server-side enforcement is a backend item.
+	const selectedWallet = data.wallets.find((w) => w.id === (watch("walletId") as number)) ?? null;
+	const overWallet =
+		effectiveDir === "Expense" && selectedWallet != null && amount > selectedWallet.balance;
+
 	// Load the partner's outstanding when settling, so the debts banner + the
 	// settlement modal have data ready.
 	useEffect(() => {
@@ -164,7 +171,7 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 	});
 
 	const onValid = (_values: PaymentFormValues): void => {
-		if (overWithdraw) {
+		if (overWithdraw || overWallet) {
 			// inline error shown; block submit
 			analytics.capture("form_validation_failed", {
 				form: "payment_create",
@@ -547,7 +554,7 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 										inputRef={field.ref}
 										size="small"
 										placeholder="0"
-										error={!!fieldError("amount") || overWithdraw}
+										error={!!fieldError("amount") || overWithdraw || overWallet}
 										slotProps={{
 											input: { endAdornment: <InputAdornment position="end">UZS</InputAdornment> },
 										}}
@@ -558,6 +565,12 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 								<Typography sx={{ fontSize: 12, color: "error.main" }}>
 									{t("payment.form.overWithdraw", {
 										advance: formatCurrency(partner?.advance ?? 0),
+									})}
+								</Typography>
+							) : overWallet ? (
+								<Typography sx={{ fontSize: 12, color: "error.main" }}>
+									{t("payment.form.overWallet", {
+										available: formatCurrency(selectedWallet?.balance ?? 0),
 									})}
 								</Typography>
 							) : (

--- a/src/components/transaction/Create/NewTransactionEntry.tsx
+++ b/src/components/transaction/Create/NewTransactionEntry.tsx
@@ -96,6 +96,11 @@ export const NewTransactionEntry: React.FC<NewTransactionEntryProps> = observer(
 	const wallets = loaded(walletStore.filteredWallets);
 	const allTemplates = loaded(templateStore.allTemplates);
 
+	// Hard-block a Supply tender that exceeds the paying wallet's balance. A Sale
+	// is money-in and its change is self-covered, so only Supply outflows are guarded.
+	const tenderWallet = wallets.find((w) => w.id === entry.pay.walletId);
+	const overWallet = !isSale && tenderWallet != null && entry.paid > tenderWallet.balance;
+
 	// Seed the warehouse + wallet defaults once their lists arrive.
 	useEffect(() => {
 		if (entry.warehouseId == null && warehouses.length > 0) {
@@ -178,11 +183,12 @@ export const NewTransactionEntry: React.FC<NewTransactionEntryProps> = observer(
 
 	const submit = () => {
 		entry.setTried(true);
-		if (!entry.valid) {
+		if (!entry.valid || overWallet) {
 			const failed = [
 				!entry.partner ? "partner" : null,
 				entry.items.length === 0 ? "items" : null,
 				entry.hasStockError ? "stock" : null,
+				overWallet ? "wallet" : null,
 			].filter((f): f is string => f !== null);
 			analytics.capture("form_validation_failed", {
 				form: isSale ? "new_sale" : "new_supply",
@@ -660,6 +666,7 @@ export const NewTransactionEntry: React.FC<NewTransactionEntryProps> = observer(
 				<TransactionSummaryCard
 					entry={entry}
 					wallets={wallets}
+					overWallet={overWallet}
 					onOpenSettle={() => setDialog("settle")}
 					onSubmit={submit}
 				/>

--- a/src/components/transaction/Create/TransactionSummaryCard.tsx
+++ b/src/components/transaction/Create/TransactionSummaryCard.tsx
@@ -20,6 +20,8 @@ import WalletPicker from "./WalletPicker";
 interface TransactionSummaryCardProps {
 	entry: UseTransactionEntry;
 	wallets: Wallet[];
+	/** True when a Supply tender exceeds the paying wallet's balance (hard-block). */
+	overWallet: boolean;
 	onOpenSettle: () => void;
 	onSubmit: () => void;
 }
@@ -75,6 +77,7 @@ const Row: React.FC<{
 export const TransactionSummaryCard: React.FC<TransactionSummaryCardProps> = ({
 	entry,
 	wallets,
+	overWallet,
 	onOpenSettle,
 	onSubmit,
 }) => {
@@ -485,6 +488,27 @@ export const TransactionSummaryCard: React.FC<TransactionSummaryCardProps> = ({
 					>
 						<ErrorOutlineIcon sx={{ fontSize: 13 }} />
 						{t("transaction.new.submit.fixQty")}
+					</Box>
+				)}
+				{tried && overWallet && (
+					<Box
+						sx={{
+							p: "10px 12px",
+							borderRadius: "6px",
+							bgcolor: designTokens.errorBg,
+							border: "1px solid",
+							borderColor: designTokens.errorBorder,
+							display: "flex",
+							alignItems: "center",
+							gap: "7px",
+							fontSize: 12.5,
+							color: "error.main",
+						}}
+					>
+						<ErrorOutlineIcon sx={{ fontSize: 13 }} />
+						{t("transaction.new.pay.overBalance", {
+							available: formatCurrency(wallets.find((w) => w.id === pay.walletId)?.balance ?? 0),
+						})}
 					</Box>
 				)}
 				<Box

--- a/src/i18n/ru/payment.json
+++ b/src/i18n/ru/payment.json
@@ -142,6 +142,7 @@
   "payment.form.walletPlaceholder": "Выберите кассу",
   "payment.form.amount": "Сумма",
   "payment.form.overWithdraw": "Аванс партнёра: {{advance}} UZS. Нельзя вывести больше.",
+  "payment.form.overWallet": "Доступно только {{available}} UZS — нельзя списать больше остатка кассы.",
   "payment.form.debtsBanner": "У партнёра есть открытые долги. При проведении откроется распределение.",
   "payment.form.immutableWarn": "Платёж нельзя изменить или удалить после проведения.",
   "payment.form.submit": "Провести платёж",

--- a/src/i18n/ru/transaction.json
+++ b/src/i18n/ru/transaction.json
@@ -292,6 +292,8 @@
   "transaction.new.pay.fillAll": "Вся сумма",
   "transaction.new.pay.walletBalance": "{{type}} · баланс {{balance}} UZS",
 
+  "transaction.new.pay.overBalance": "Доступно только {{available}} UZS — нельзя списать больше остатка кассы.",
+
   "transaction.new.submit.fixQty": "Исправьте количество в выделенных позициях",
   "transaction.new.submit.immutable.Sale": "Продажа записывается окончательно — изменить нельзя, только оформить возврат.",
   "transaction.new.submit.immutable.Supply": "Поставка записывается окончательно — изменить нельзя, только оформить возврат.",


### PR DESCRIPTION
Ratified decision: a wallet payment or POS tender may not drive a wallet negative (parity with the stock hard-block). Mirrors the existing wallet-transfer guard onto the two unguarded outflows.

## Changes
- **Standalone payments** (`PaymentCreateModal`): when the effective direction is `Expense` and the amount exceeds the selected wallet's balance, block submit and show an inline "exceeds balance" message on the amount field. Keys off `effectiveDir === "Expense"` (the same predicate the store uses), not the payment type.
- **POS tender** (`NewTransactionEntry` + `TransactionSummaryCard`): a Supply pays money out of a wallet — block when the tender exceeds the wallet balance, alongside the existing stock guard. A Sale is money-in and its change is self-covered, so Sale is deliberately **not** guarded.

Balance stays backend-served (hard rule 8); the guard only compares against it. **Server-side enforcement is a backend open item.**

## Verification
`npm run validate` green. **Live-verified:** a General/Expense payment of 1,000,000 against the wallet shows the inline over-balance message and blocks submission.

⚠️ Flagged: the payment form's wallet balance (`PaymentWalletRef.balance`) displayed as `0` while the wallets list showed a different (negative) balance for the same wallet — worth verifying the served balance is the true one (added to backend open items).