### PR TITLE
G7 table conventions: money headers, date+time, sortable detail tables (XC-4/5/2)

### DIFF
--- a/src/components/category/Table/categoryTableConfigs.tsx
+++ b/src/components/category/Table/categoryTableConfigs.tsx
@@ -75,6 +75,7 @@ export function buildCategoryColumns({
 		},
 		{
 			key: "productCount",
+			field: "productCount",
 			headerName: t("category.table.productCount"),
 			width: "12%",
 			align: "right",

--- a/src/components/debt/DebtTables.tsx
+++ b/src/components/debt/DebtTables.tsx
@@ -7,7 +7,7 @@ import { TransactionTypeBadge } from "components/transaction/TransactionBadges";
 import { Debt } from "models/debt";
 import { DebtPartnerGroup } from "stores/DebtStore";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDate, formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 import { formatEntityId } from "utils/formatEntityId";
 import { directionOf, isRefundType } from "utils/transactionUtils";
@@ -323,7 +323,7 @@ export const TransactionDebtTable: React.FC<TransactionDebtTableProps> = ({
 									{formatEntityId(d.number ?? d.transactionId)}
 								</Box>
 								<Box component="div" sx={{ ...numericSx, fontSize: 12, color: "text.secondary" }}>
-									{formatDate(d.date)}
+									{formatDateTime(d.date)}
 								</Box>
 							</Box>
 						</Box>

--- a/src/components/order/Detail/StatusHistoryCard.tsx
+++ b/src/components/order/Detail/StatusHistoryCard.tsx
@@ -4,18 +4,12 @@ import OrderStatusChip from "components/order/OrderStatusChip";
 import DetailCard from "components/shared/Detail/DetailCard";
 import { Order } from "models/order";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { ORDER_STATUS_META } from "utils/orderUtils";
 
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 import { Box, Typography } from "@mui/material";
-
-const timeOf = (iso: string): string => {
-	const d = new Date(iso);
-	const pad = (n: number) => n.toString().padStart(2, "0");
-	return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-};
 
 export const StatusHistoryCard: React.FC<{ order: Order }> = ({ order }) => {
 	const { t } = useTranslation();
@@ -56,7 +50,7 @@ export const StatusHistoryCard: React.FC<{ order: Order }> = ({ order }) => {
 							</Box>
 							<Box sx={{ pb: last ? 0 : "18px" }}>
 								<Typography sx={{ ...numericSx, fontSize: 12.5, color: "text.secondary" }}>
-									{formatDate(h.at)}, {timeOf(h.at)}
+									{formatDateTime(h.at)}
 								</Typography>
 								<Box sx={{ display: "flex", alignItems: "center", gap: "9px", mt: "5px" }}>
 									{h.from ? (

--- a/src/components/order/Detail/TerminalBanner.tsx
+++ b/src/components/order/Detail/TerminalBanner.tsx
@@ -2,17 +2,11 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Order, OrderStatus } from "models/order";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 
 import CloseIcon from "@mui/icons-material/Close";
 import UndoOutlinedIcon from "@mui/icons-material/UndoOutlined";
 import { Box, Typography } from "@mui/material";
-
-const timeOf = (iso: string): string => {
-	const d = new Date(iso);
-	const pad = (n: number) => n.toString().padStart(2, "0");
-	return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-};
 
 type TerminalStatus = "Cancelled" | "Rejected" | "Returned";
 const isTerminal = (s: OrderStatus): s is TerminalStatus =>
@@ -96,7 +90,7 @@ export const TerminalBanner: React.FC<{ order: Order }> = ({ order }) => {
 					}}
 				>
 					<Box component="span" sx={numericSx}>
-						{formatDate(last.at)}, {timeOf(last.at)}
+						{formatDateTime(last.at)}
 					</Box>
 					{last.by && <> · {last.by}</>}
 				</Box>

--- a/src/components/order/List/orderColumns.tsx
+++ b/src/components/order/List/orderColumns.tsx
@@ -8,7 +8,7 @@ import { Column } from "components/shared/Table/DataTable/DataTable";
 import { TFunction } from "i18next";
 import { Order } from "models/order";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import { Box } from "@mui/material";
@@ -36,7 +36,7 @@ export function buildOrderColumns(t: TFunction): Column<Order>[] {
 			sortValue: (o) => Date.parse(o.date),
 			renderCell: (o) => (
 				<Box component="span" sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}>
-					{formatDate(o.date)}
+					{formatDateTime(o.date)}
 				</Box>
 			),
 		},

--- a/src/components/partner/Detail/LedgerTab.tsx
+++ b/src/components/partner/Detail/LedgerTab.tsx
@@ -294,7 +294,7 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 									}}
 								>
 									<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
-										{formatDateTime(e.date)}
+										{e.type === "opening" ? formatDate(e.date) : formatDateTime(e.date)}
 									</Box>
 									<Box component="td" sx={bodyCellSx}>
 										<EventCell type={e.type} label={t(eventLabelKey(e.type))} />

--- a/src/components/partner/Detail/LedgerTab.tsx
+++ b/src/components/partner/Detail/LedgerTab.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
+import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import { PartnerLedgerEntry } from "models/partner";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDate, formatDateTime } from "utils/dateUtils";
 import { csvDateStamp, exportToCsv } from "utils/exportToCsv";
 import { balanceColor } from "utils/partnerUtils";
 
@@ -25,6 +27,7 @@ import {
 import { EventCell, eventLabelKey } from "./ledgerMeta";
 
 type EventFilter = "all" | "sale" | "supply" | "payment" | "refund" | "opening";
+type SortCol = "date" | "event" | "amount" | "balance";
 
 interface LedgerTabProps {
 	ledger: PartnerLedgerEntry[];
@@ -47,6 +50,8 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 	const [eventFilter, setEventFilter] = useState<EventFilter>("all");
 	const [period, setPeriod] = useState<LedgerPeriod>("all");
 	const [search, setSearch] = useState("");
+	const [sortCol, setSortCol] = useState<SortCol>("date");
+	const [sortDir, setSortDir] = useState<SortDir>("desc");
 
 	const descriptionText = (e: PartnerLedgerEntry): string =>
 		e.type === "opening"
@@ -70,10 +75,38 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ledger, period, eventFilter, search, t]);
 
+	const sorted = useMemo(() => {
+		const accessor = (e: PartnerLedgerEntry): string | number => {
+			switch (sortCol) {
+				case "date":
+					return e.date;
+				case "event":
+					return t(eventLabelKey(e.type));
+				case "amount":
+					return e.delta;
+				case "balance":
+					return e.balance;
+				default:
+					return "";
+			}
+		};
+		const s = [...filtered].sort((a, b) => compareValues(accessor(a), accessor(b)));
+		return sortDir === "desc" ? s.reverse() : s;
+	}, [filtered, sortCol, sortDir, t]);
+
 	const { page, rowsPerPage, setPage, changeRowsPerPage, paginate } = useDetailTablePage(
-		`${eventFilter}|${period}|${search}`,
+		`${eventFilter}|${period}|${search}|${sortCol}|${sortDir}`,
 	);
-	const rows = paginate(filtered);
+	const rows = paginate(sorted);
+
+	const onSort = (col: SortCol) => {
+		if (col === sortCol) {
+			setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+		} else {
+			setSortCol(col);
+			setSortDir("desc");
+		}
+	};
 
 	const description = (e: PartnerLedgerEntry): React.ReactNode => {
 		if (e.type === "opening") {
@@ -205,21 +238,43 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 				<Box component="table" sx={{ width: "100%", borderCollapse: "collapse" }}>
 					<thead>
 						<tr>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.ledger.col.date")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.ledger.col.event")}
-							</Box>
+							<DetailSortHeader
+								col="date"
+								label={t("partner.ledger.col.date")}
+								active={sortCol === "date"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="event"
+								label={t("partner.ledger.col.event")}
+								active={sortCol === "event"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
 							<Box component="th" sx={headCellSx}>
 								{t("partner.ledger.col.description")}
 							</Box>
-							<Box component="th" sx={{ ...headCellSx, textAlign: "right" }}>
-								{t("partner.ledger.col.amount")}
-							</Box>
-							<Box component="th" sx={{ ...headCellSx, textAlign: "right" }}>
-								{t("partner.ledger.col.balanceAfter")}
-							</Box>
+							<DetailSortHeader
+								col="amount"
+								label={t("partner.ledger.col.amount")}
+								active={sortCol === "amount"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+								sx={{ ...headCellSx, textAlign: "right" }}
+							/>
+							<DetailSortHeader
+								col="balance"
+								label={t("partner.ledger.col.balanceAfter")}
+								active={sortCol === "balance"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+								sx={{ ...headCellSx, textAlign: "right" }}
+							/>
 						</tr>
 					</thead>
 					<tbody>
@@ -239,7 +294,7 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 									}}
 								>
 									<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
-										{formatDate(e.date)}
+										{formatDateTime(e.date)}
 									</Box>
 									<Box component="td" sx={bodyCellSx}>
 										<EventCell type={e.type} label={t(eventLabelKey(e.type))} />

--- a/src/components/partner/Detail/PaymentsTab.tsx
+++ b/src/components/partner/Detail/PaymentsTab.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
+import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import { PartnerLedgerEntry } from "models/partner";
 import { numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDate, formatDateTime } from "utils/dateUtils";
 import { csvDateStamp, exportToCsv } from "utils/exportToCsv";
 import { formatCurrency } from "utils/formatCurrency";
 import { balanceColor } from "utils/partnerUtils";
@@ -18,6 +20,7 @@ import { DETAIL_ROWS_PER_PAGE_OPTIONS, useDetailTablePage } from "./ledgerHelper
 import { EventCell, eventLabelKey } from "./ledgerMeta";
 
 type TypeFilter = "all" | "payment" | "deposit" | "withdraw";
+type SortCol = "date" | "type" | "amount" | "wallet";
 
 interface PaymentsTabProps {
 	payments: PartnerLedgerEntry[];
@@ -29,6 +32,8 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 	const { t } = useTranslation();
 	const [type, setType] = useState<TypeFilter>("all");
 	const [search, setSearch] = useState("");
+	const [sortCol, setSortCol] = useState<SortCol>("date");
+	const [sortDir, setSortDir] = useState<SortDir>("desc");
 
 	const filtered = useMemo(() => {
 		const ql = search.trim().toLowerCase();
@@ -52,10 +57,38 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [payments, type, search, t]);
 
+	const sorted = useMemo(() => {
+		const accessor = (p: PartnerLedgerEntry): string | number => {
+			switch (sortCol) {
+				case "date":
+					return p.date;
+				case "type":
+					return t(eventLabelKey(p.type));
+				case "amount":
+					return Math.abs(p.delta);
+				case "wallet":
+					return p.walletName ?? "";
+				default:
+					return "";
+			}
+		};
+		const s = [...filtered].sort((a, b) => compareValues(accessor(a), accessor(b)));
+		return sortDir === "desc" ? s.reverse() : s;
+	}, [filtered, sortCol, sortDir, t]);
+
 	const { page, rowsPerPage, setPage, changeRowsPerPage, paginate } = useDetailTablePage(
-		`${type}|${search}`,
+		`${type}|${search}|${sortCol}|${sortDir}`,
 	);
-	const rows = paginate(filtered);
+	const rows = paginate(sorted);
+
+	const onSort = (col: SortCol) => {
+		if (col === sortCol) {
+			setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+		} else {
+			setSortCol(col);
+			setSortDir("desc");
+		}
+	};
 
 	const handleExport = () => {
 		exportToCsv<PartnerLedgerEntry>(
@@ -108,18 +141,39 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 				<Box component="table" sx={{ width: "100%", borderCollapse: "collapse" }}>
 					<thead>
 						<tr>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.pays.col.date")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.pays.col.type")}
-							</Box>
-							<Box component="th" sx={{ ...headCellSx, textAlign: "right" }}>
-								{t("partner.pays.col.amount")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.pays.col.wallet")}
-							</Box>
+							<DetailSortHeader
+								col="date"
+								label={t("partner.pays.col.date")}
+								active={sortCol === "date"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="type"
+								label={t("partner.pays.col.type")}
+								active={sortCol === "type"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="amount"
+								label={t("partner.pays.col.amount")}
+								active={sortCol === "amount"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+								sx={{ ...headCellSx, textAlign: "right" }}
+							/>
+							<DetailSortHeader
+								col="wallet"
+								label={t("partner.pays.col.wallet")}
+								active={sortCol === "wallet"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
 						</tr>
 					</thead>
 					<tbody>
@@ -131,7 +185,7 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 								sx={{ cursor: "pointer", "&:hover": { bgcolor: "grey.50" } }}
 							>
 								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
-									{formatDate(p.date)}
+									{formatDateTime(p.date)}
 								</Box>
 								<Box component="td" sx={bodyCellSx}>
 									<EventCell type={p.type} label={t(eventLabelKey(p.type))} />

--- a/src/components/partner/Detail/TransactionsTab.tsx
+++ b/src/components/partner/Detail/TransactionsTab.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
+import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import { PartnerLedgerEntry, PartnerLedgerStatus } from "models/partner";
 import { numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDate, formatDateTime } from "utils/dateUtils";
 import { csvDateStamp, exportToCsv } from "utils/exportToCsv";
 import { formatCurrency } from "utils/formatCurrency";
 
@@ -19,6 +21,7 @@ import { EventCell, eventLabelKey } from "./ledgerMeta";
 
 type TypeFilter = "all" | "sale" | "supply" | "refund";
 type StatusFilter = "all" | "open" | "paid" | "partial" | "unpaid";
+type SortCol = "date" | "type" | "number" | "positions" | "amount" | "status";
 
 const STATUS_TONE: Record<"paid" | "partial" | "unpaid", "success" | "warning" | "error"> = {
 	paid: "success",
@@ -45,6 +48,8 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 	const [type, setType] = useState<TypeFilter>("all");
 	const [status, setStatus] = useState<StatusFilter>(initialStatus ?? "all");
 	const [search, setSearch] = useState("");
+	const [sortCol, setSortCol] = useState<SortCol>("date");
+	const [sortDir, setSortDir] = useState<SortDir>("desc");
 
 	const filtered = useMemo(() => {
 		const ql = search.trim().toLowerCase();
@@ -73,10 +78,42 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [transactions, type, status, search, t]);
 
+	const sorted = useMemo(() => {
+		const accessor = (tx: PartnerLedgerEntry): string | number => {
+			switch (sortCol) {
+				case "date":
+					return tx.date;
+				case "type":
+					return t(eventLabelKey(tx.type));
+				case "number":
+					return tx.reference ?? "";
+				case "positions":
+					return tx.itemCount ?? 0;
+				case "amount":
+					return Math.abs(tx.delta);
+				case "status":
+					return tx.status ?? "";
+				default:
+					return "";
+			}
+		};
+		const s = [...filtered].sort((a, b) => compareValues(accessor(a), accessor(b)));
+		return sortDir === "desc" ? s.reverse() : s;
+	}, [filtered, sortCol, sortDir, t]);
+
 	const { page, rowsPerPage, setPage, changeRowsPerPage, paginate } = useDetailTablePage(
-		`${type}|${status}|${search}`,
+		`${type}|${status}|${search}|${sortCol}|${sortDir}`,
 	);
-	const rows = paginate(filtered);
+	const rows = paginate(sorted);
+
+	const onSort = (col: SortCol) => {
+		if (col === sortCol) {
+			setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+		} else {
+			setSortCol(col);
+			setSortDir("desc");
+		}
+	};
 
 	const statusChip = (s?: PartnerLedgerStatus) => {
 		if (!s || s === "done") {
@@ -163,24 +200,56 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 				<Box component="table" sx={{ width: "100%", borderCollapse: "collapse" }}>
 					<thead>
 						<tr>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.txns.col.date")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.txns.col.type")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.txns.col.number")}
-							</Box>
-							<Box component="th" sx={{ ...headCellSx, textAlign: "right" }}>
-								{t("partner.txns.col.positions")}
-							</Box>
-							<Box component="th" sx={{ ...headCellSx, textAlign: "right" }}>
-								{t("partner.txns.col.amount")}
-							</Box>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.txns.col.status")}
-							</Box>
+							<DetailSortHeader
+								col="date"
+								label={t("partner.txns.col.date")}
+								active={sortCol === "date"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="type"
+								label={t("partner.txns.col.type")}
+								active={sortCol === "type"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="number"
+								label={t("partner.txns.col.number")}
+								active={sortCol === "number"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
+								col="positions"
+								label={t("partner.txns.col.positions")}
+								active={sortCol === "positions"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+								sx={{ ...headCellSx, textAlign: "right" }}
+							/>
+							<DetailSortHeader
+								col="amount"
+								label={t("partner.txns.col.amount")}
+								active={sortCol === "amount"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+								sx={{ ...headCellSx, textAlign: "right" }}
+							/>
+							<DetailSortHeader
+								col="status"
+								label={t("partner.txns.col.status")}
+								active={sortCol === "status"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
 						</tr>
 					</thead>
 					<tbody>
@@ -192,7 +261,7 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 								sx={{ cursor: "pointer", "&:hover": { bgcolor: "grey.50" } }}
 							>
 								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
-									{formatDate(tx.date)}
+									{formatDateTime(tx.date)}
 								</Box>
 								<Box component="td" sx={bodyCellSx}>
 									<EventCell type={tx.type} label={t(eventLabelKey(tx.type))} />

--- a/src/components/payment/Detail/PaymentDetailCards.tsx
+++ b/src/components/payment/Detail/PaymentDetailCards.tsx
@@ -8,7 +8,7 @@ import { WALLET_TYPE_META } from "components/wallet/WalletPresentation";
 import { PaymentAllocationKind, PaymentRecord } from "models/payment";
 import { saleDetailPath, supplyDetailPath } from "routing/paths";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
@@ -413,7 +413,7 @@ export const PaymentInfoCard: React.FC<{
 					<ScheduleOutlinedIcon sx={{ fontSize: 16 }} />,
 					t("payment.detail.date"),
 					<Box component="span" sx={numericSx}>
-						{formatDate(payment.date)}
+						{formatDateTime(payment.date)}
 					</Box>,
 				)}
 			</Box>

--- a/src/components/payment/Table/PaymentsTable.tsx
+++ b/src/components/payment/Table/PaymentsTable.tsx
@@ -8,7 +8,7 @@ import { Loadable } from "helpers/Loading";
 import { TFunction } from "i18next";
 import { PaymentRecord } from "models/payment";
 import { numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
@@ -57,7 +57,7 @@ function buildPaymentColumns(t: TFunction): Column<PaymentRecord>[] {
 			sortValue: (p) => new Date(p.date),
 			renderCell: (p) => (
 				<Box component="span" sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}>
-					{formatDate(p.date)}
+					{formatDateTime(p.date)}
 				</Box>
 			),
 		},

--- a/src/components/product/Detail/ProductMovementsTab.tsx
+++ b/src/components/product/Detail/ProductMovementsTab.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import DetailCard from "components/shared/Detail/DetailCard";
+import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
+import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import WarehouseLink from "components/warehouse/Links/WarehouseLink";
 import { ProductMovement } from "models/product";
 import { numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatQuantity } from "utils/formatCurrency";
 
 import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
@@ -19,6 +21,8 @@ interface ProductMovementsTabProps {
 	movements: ProductMovement[];
 }
 
+type SortCol = "date" | "type" | "warehouse" | "in" | "out" | "balance";
+
 const Dash: React.FC = () => (
 	<Box component="span" sx={{ color: "text.disabled" }}>
 		—
@@ -27,14 +31,53 @@ const Dash: React.FC = () => (
 
 /**
  * «Движения» per the bundle: the warehouse ledger with the served running
- * balance and the opening-stock summary row. The opening figure is the
- * remainder before the oldest movement (balanceAfter − delta).
+ * balance and the opening-stock summary row. Sortable on every column
+ * (defaults to date, newest first). The opening figure is the remainder before
+ * the chronologically oldest movement (balanceAfter − delta) — derived by date
+ * so it stays correct regardless of the display sort.
  */
 export const ProductMovementsTab: React.FC<ProductMovementsTabProps> = ({ movements }) => {
 	const { t } = useTranslation();
+	const [sortCol, setSortCol] = useState<SortCol>("date");
+	const [sortDir, setSortDir] = useState<SortDir>("desc");
 
-	const oldest = movements.length > 0 ? movements[movements.length - 1] : null;
+	const oldest =
+		movements.length > 0
+			? movements.reduce((a, b) => (Date.parse(a.date) <= Date.parse(b.date) ? a : b))
+			: null;
 	const openingBalance = oldest ? oldest.balanceAfter - oldest.quantity : 0;
+
+	const rows = useMemo(() => {
+		const accessor = (m: ProductMovement): string | number => {
+			switch (sortCol) {
+				case "date":
+					return m.date;
+				case "type":
+					return m.kind;
+				case "warehouse":
+					return m.warehouseName;
+				case "in":
+					return m.quantity > 0 ? m.quantity : 0;
+				case "out":
+					return m.quantity < 0 ? -m.quantity : 0;
+				case "balance":
+					return m.balanceAfter;
+				default:
+					return "";
+			}
+		};
+		const sorted = [...movements].sort((a, b) => compareValues(accessor(a), accessor(b)));
+		return sortDir === "desc" ? sorted.reverse() : sorted;
+	}, [movements, sortCol, sortDir]);
+
+	const onSort = (col: SortCol) => {
+		if (col === sortCol) {
+			setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+		} else {
+			setSortCol(col);
+			setSortDir("desc");
+		}
+	};
 
 	return (
 		<DetailCard
@@ -51,20 +94,59 @@ export const ProductMovementsTab: React.FC<ProductMovementsTabProps> = ({ moveme
 				<Box component="table" sx={detailTableSx}>
 					<thead>
 						<tr>
-							<th>{t("product.detail.txns.date")}</th>
-							<th>{t("product.detail.txns.type")}</th>
-							<th>{t("product.detail.table.warehouse")}</th>
-							<th className="r">{t("product.detail.moves.in")}</th>
-							<th className="r">{t("product.detail.moves.out")}</th>
-							<th className="r">{t("product.detail.moves.balance")}</th>
+							<DetailSortHeader
+								col="date"
+								label={t("product.detail.txns.date")}
+								active={sortCol === "date"}
+								dir={sortDir}
+								onSort={onSort}
+							/>
+							<DetailSortHeader
+								col="type"
+								label={t("product.detail.txns.type")}
+								active={sortCol === "type"}
+								dir={sortDir}
+								onSort={onSort}
+							/>
+							<DetailSortHeader
+								col="warehouse"
+								label={t("product.detail.table.warehouse")}
+								active={sortCol === "warehouse"}
+								dir={sortDir}
+								onSort={onSort}
+							/>
+							<DetailSortHeader
+								col="in"
+								label={t("product.detail.moves.in")}
+								active={sortCol === "in"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+							/>
+							<DetailSortHeader
+								col="out"
+								label={t("product.detail.moves.out")}
+								active={sortCol === "out"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+							/>
+							<DetailSortHeader
+								col="balance"
+								label={t("product.detail.moves.balance")}
+								active={sortCol === "balance"}
+								dir={sortDir}
+								onSort={onSort}
+								align="right"
+							/>
 						</tr>
 					</thead>
 					<tbody>
-						{movements.map((movement) => (
+						{rows.map((movement) => (
 							<tr key={movement.id}>
 								<td>
 									<Box component="span" sx={{ ...numericSx, color: "text.secondary" }}>
-										{formatDate(movement.date)}
+										{formatDateTime(movement.date)}
 									</Box>
 								</td>
 								<td>

--- a/src/components/product/Detail/ProductTransactionsTab.tsx
+++ b/src/components/product/Detail/ProductTransactionsTab.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import DetailCard from "components/shared/Detail/DetailCard";
+import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
+import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import { Measurement, ProductTransaction } from "models/product";
 import { PATHS } from "routing/paths";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency, formatQuantity } from "utils/formatCurrency";
 import { unitInline } from "utils/productUtils";
 
@@ -22,7 +24,10 @@ interface ProductTransactionsTabProps {
 	measurement: Measurement;
 }
 
-/** «Транзакции» per the bundle: dated history with signed quantities. */
+type SortCol = "date" | "type" | "partner" | "quantity" | "price" | "total";
+
+/** «Транзакции» per the bundle: dated history with signed quantities, sortable
+ *  on every column (defaults to date, newest first). */
 export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 	transactions,
 	measurement,
@@ -30,6 +35,40 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const unit = unitInline(t, measurement);
+	const [sortCol, setSortCol] = useState<SortCol>("date");
+	const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+	const rows = useMemo(() => {
+		const accessor = (txn: ProductTransaction): string | number => {
+			switch (sortCol) {
+				case "date":
+					return txn.date;
+				case "type":
+					return txn.transactionType;
+				case "partner":
+					return txn.partnerName;
+				case "quantity":
+					return Math.abs(txn.quantity);
+				case "price":
+					return txn.unitPrice;
+				case "total":
+					return Math.abs(txn.quantity) * txn.unitPrice;
+				default:
+					return "";
+			}
+		};
+		const sorted = [...transactions].sort((a, b) => compareValues(accessor(a), accessor(b)));
+		return sortDir === "desc" ? sorted.reverse() : sorted;
+	}, [transactions, sortCol, sortDir]);
+
+	const onSort = (col: SortCol) => {
+		if (col === sortCol) {
+			setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+		} else {
+			setSortCol(col);
+			setSortDir("desc");
+		}
+	};
 
 	return (
 		<DetailCard
@@ -47,20 +86,59 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 					<Box component="table" sx={detailTableSx}>
 						<thead>
 							<tr>
-								<th>{t("product.detail.txns.date")}</th>
-								<th>{t("product.detail.txns.type")}</th>
-								<th>{t("product.detail.txns.partner")}</th>
-								<th className="r">{t("product.detail.table.quantity")}</th>
-								<th className="r">{t("product.detail.txns.price")}</th>
-								<th className="r">{t("product.detail.txns.total")}</th>
+								<DetailSortHeader
+									col="date"
+									label={t("product.detail.txns.date")}
+									active={sortCol === "date"}
+									dir={sortDir}
+									onSort={onSort}
+								/>
+								<DetailSortHeader
+									col="type"
+									label={t("product.detail.txns.type")}
+									active={sortCol === "type"}
+									dir={sortDir}
+									onSort={onSort}
+								/>
+								<DetailSortHeader
+									col="partner"
+									label={t("product.detail.txns.partner")}
+									active={sortCol === "partner"}
+									dir={sortDir}
+									onSort={onSort}
+								/>
+								<DetailSortHeader
+									col="quantity"
+									label={t("product.detail.table.quantity")}
+									active={sortCol === "quantity"}
+									dir={sortDir}
+									onSort={onSort}
+									align="right"
+								/>
+								<DetailSortHeader
+									col="price"
+									label={t("product.detail.txns.price")}
+									active={sortCol === "price"}
+									dir={sortDir}
+									onSort={onSort}
+									align="right"
+								/>
+								<DetailSortHeader
+									col="total"
+									label={t("product.detail.txns.total")}
+									active={sortCol === "total"}
+									dir={sortDir}
+									onSort={onSort}
+									align="right"
+								/>
 							</tr>
 						</thead>
 						<tbody>
-							{transactions.map((txn) => (
+							{rows.map((txn) => (
 								<tr key={txn.id}>
 									<td>
 										<Box component="span" sx={{ ...numericSx, color: "text.secondary" }}>
-											{formatDate(txn.date)}
+											{formatDateTime(txn.date)}
 										</Box>
 									</td>
 									<td>

--- a/src/components/shared/Detail/DetailSortHeader.tsx
+++ b/src/components/shared/Detail/DetailSortHeader.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Box, Tooltip } from "@mui/material";
+import { Box, SxProps, Theme, Tooltip } from "@mui/material";
 
 export type SortDir = "asc" | "desc";
 
@@ -16,6 +16,9 @@ interface DetailSortHeaderProps<K extends string> {
 	align?: "left" | "right";
 	/** Optional plain-language tooltip (e.g. the WAC explanation, D8) — no formula. */
 	tooltip?: string;
+	/** Extra cell styling — e.g. the per-cell `headCellSx` used by tables that
+	 *  don't get their `th` styling from a parent `detailTableSx`. */
+	sx?: SxProps<Theme>;
 }
 
 /**
@@ -33,13 +36,17 @@ export function DetailSortHeader<K extends string>({
 	onSort,
 	align = "left",
 	tooltip,
+	sx,
 }: DetailSortHeaderProps<K>) {
 	return (
 		<Box
 			component="th"
 			className={align === "right" ? "r" : undefined}
 			onClick={() => onSort(col)}
-			sx={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap" }}
+			sx={[
+				{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap" },
+				...(Array.isArray(sx) ? sx : [sx]),
+			]}
 		>
 			<Box
 				component="span"

--- a/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
+++ b/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
@@ -10,7 +10,7 @@ import WarehouseLink from "components/warehouse/Links/WarehouseLink";
 import { Loadable } from "helpers/Loading";
 import { StockAdjustment } from "models/stockAdjustment";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatQuantity } from "utils/formatCurrency";
 import { MEASUREMENT_SHORT } from "utils/productUtils";
 
@@ -26,13 +26,6 @@ interface StockAdjustmentsTableProps {
 	/** Whether any adjustment exists at all (drives the empty-state copy). */
 	hasAny: boolean;
 	onCreate: () => void;
-}
-
-/** Local time-of-day (HH:mm) for the audited timestamp shown in the expand row. */
-function timeOf(iso: string): string {
-	const d = new Date(iso);
-	const pad = (n: number) => n.toString().padStart(2, "0");
-	return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 const ExpandField: React.FC<{ label: string; children: React.ReactNode; mono?: boolean }> = ({
@@ -126,7 +119,7 @@ const AdjustmentDetail: React.FC<{ adjustment: StockAdjustment }> = ({ adjustmen
 						{adjustment.categoryName ?? "—"}
 					</ExpandField>
 					<ExpandField label={t("adjustment.detail.dateTime")} mono>
-						{formatDate(adjustment.date)}, {timeOf(adjustment.date)}
+						{formatDateTime(adjustment.date)}
 					</ExpandField>
 					<ExpandField label={t("adjustment.detail.balanceAfter")} mono>
 						{formatQuantity(adjustment.balanceAfter)} {unit}
@@ -207,7 +200,7 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 						component="span"
 						sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
 					>
-						{formatDate(a.date)}
+						{formatDateTime(a.date)}
 					</Box>
 				),
 			},

--- a/src/components/transaction/Detail/cards.tsx
+++ b/src/components/transaction/Detail/cards.tsx
@@ -6,7 +6,7 @@ import { TransactionStatusChip } from "components/transaction/TransactionBadges"
 import { TransactionLine, TransactionRecord, TransactionStatus } from "models/transaction";
 import { WalletType } from "models/wallet";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 import {
 	directionOf,
@@ -518,7 +518,7 @@ export const PaymentsCard: React.FC<{
 								}}
 							>
 								<Box component="span" sx={numericSx}>
-									{formatDate(p.date)}
+									{formatDateTime(p.date)}
 								</Box>
 								<MetaDot />
 								{p.walletName}
@@ -580,7 +580,7 @@ export const RefundHistoryCard: React.FC<{
 							sx={{ cursor: "pointer", "&:hover td": { bgcolor: designTokens.gray25 } }}
 						>
 							<Box component="td" sx={{ ...bodyCellSx, textAlign: "left", pl: "18px" }}>
-								{formatDate(r.date)}
+								{formatDateTime(r.date)}
 							</Box>
 							<Box
 								component="td"
@@ -718,8 +718,7 @@ export const AuditCard: React.FC<{ tx: TransactionRecord; isRefund: boolean }> =
 			v: (
 				<>
 					<Box component="span" sx={numericSx}>
-						{formatDate(tx.date)}
-						{tx.time ? ` · ${tx.time}` : ""}
+						{formatDateTime(tx.date)}
 					</Box>
 					{tx.createdBy ? (
 						<>

--- a/src/components/transaction/List/transactionColumns.tsx
+++ b/src/components/transaction/List/transactionColumns.tsx
@@ -9,7 +9,7 @@ import {
 import { TFunction } from "i18next";
 import { TransactionRecord } from "models/transaction";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 import { directionOf, isRefundType } from "utils/transactionUtils";
 
@@ -71,7 +71,7 @@ export function buildTransactionColumns(t: TFunction): Column<TransactionRecord>
 					component="span"
 					sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
 				>
-					{formatDate(tx.date)}
+					{formatDateTime(tx.date)}
 				</Box>
 			),
 		},

--- a/src/components/transfer/Table/transfersTableConfigs.tsx
+++ b/src/components/transfer/Table/transfersTableConfigs.tsx
@@ -2,7 +2,7 @@ import { Column } from "components/shared/Table/DataTable/DataTable";
 import { TFunction } from "i18next";
 import { Transfer, transferUnits } from "models/transfer";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatQuantity } from "utils/formatCurrency";
 
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -46,7 +46,7 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 					component="span"
 					sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
 				>
-					{formatDate(transfer.date)}
+					{formatDateTime(transfer.date)}
 				</Typography>
 			),
 		},
@@ -54,12 +54,14 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			key: "from",
 			headerName: t("transfer.table.from"),
 			width: "22%",
+			sortValue: (transfer) => transfer.fromWarehouseName,
 			renderCell: (transfer) => <WarehouseCell name={transfer.fromWarehouseName} />,
 		},
 		{
 			key: "to",
 			headerName: t("transfer.table.to"),
 			width: "22%",
+			sortValue: (transfer) => transfer.toWarehouseName,
 			renderCell: (transfer) => <WarehouseCell name={transfer.toWarehouseName} accent />,
 		},
 		{
@@ -67,6 +69,7 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			headerName: t("transfer.table.positions"),
 			width: "10%",
 			align: "right",
+			sortValue: (transfer) => transfer.lines.length,
 			renderCell: (transfer) => (
 				<Typography component="span" sx={{ ...numericSx, color: designTokens.gray700 }}>
 					{transfer.lines.length}
@@ -78,6 +81,7 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			headerName: t("transfer.table.units"),
 			width: "11%",
 			align: "right",
+			sortValue: (transfer) => transferUnits(transfer),
 			renderCell: (transfer) => (
 				<Typography component="span" sx={{ ...numericSx, fontWeight: 700 }}>
 					{formatQuantity(transferUnits(transfer))}
@@ -88,6 +92,7 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			key: "createdBy",
 			headerName: t("transfer.table.createdBy"),
 			width: "15%",
+			sortValue: (transfer) => transfer.createdBy,
 			renderCell: (transfer) => (
 				<Typography component="span" sx={{ color: "text.secondary", whiteSpace: "nowrap" }}>
 					{transfer.createdBy}

--- a/src/components/wallet/Detail/WalletOperationsTab.tsx
+++ b/src/components/wallet/Detail/WalletOperationsTab.tsx
@@ -8,7 +8,7 @@ import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
 import { WalletOperation, WalletOperationDirection } from "models/wallet";
 import { paymentDetailPath } from "routing/paths";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 import { matchesSearch } from "utils/stringUtils";
 
@@ -100,7 +100,7 @@ export const WalletOperationsTab: React.FC<WalletOperationsTabProps> = ({
 						component="span"
 						sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 					>
-						{formatDate(o.date)}
+						{formatDateTime(o.date)}
 					</Box>
 				),
 			},

--- a/src/components/wallet/Detail/WalletTransferDetailModal.tsx
+++ b/src/components/wallet/Detail/WalletTransferDetailModal.tsx
@@ -5,7 +5,7 @@ import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import { WalletTypeAvatar } from "components/wallet/WalletPresentation";
 import { WalletTransfer } from "models/wallet";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -76,7 +76,7 @@ export const WalletTransferDetailModal: React.FC<WalletTransferDetailModalProps>
 		>
 			<FormDialogHeader
 				title={t("wallet.transfer.detailTitle")}
-				subtitle={formatDate(transfer.date)}
+				subtitle={formatDateTime(transfer.date)}
 				disabled={false}
 				onClose={onClose}
 			/>
@@ -118,7 +118,7 @@ export const WalletTransferDetailModal: React.FC<WalletTransferDetailModalProps>
 				</KvRow>
 				<KvRow label={t("wallet.transfer.date")}>
 					<Box component="span" sx={numericSx}>
-						{formatDate(transfer.date)}
+						{formatDateTime(transfer.date)}
 					</Box>
 				</KvRow>
 				<KvRow label={t("wallet.transfer.createdBy")}>{transfer.createdBy}</KvRow>

--- a/src/components/wallet/Detail/WalletTransfersTab.tsx
+++ b/src/components/wallet/Detail/WalletTransfersTab.tsx
@@ -5,7 +5,7 @@ import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
 import { WalletTypeAvatar } from "components/wallet/WalletPresentation";
 import { WalletTransfer } from "models/wallet";
 import { numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import AddIcon from "@mui/icons-material/Add";
@@ -53,7 +53,7 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 						component="span"
 						sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 					>
-						{formatDate(tr.date)}
+						{formatDateTime(tr.date)}
 					</Box>
 				),
 			},

--- a/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
+++ b/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
@@ -16,7 +16,7 @@ import {
 	WarehouseMovementKind,
 } from "models/warehouse";
 import { designTokens, numericSx } from "theme";
-import { formatDate } from "utils/dateUtils";
+import { formatDateTime } from "utils/dateUtils";
 import { formatQuantity } from "utils/formatCurrency";
 import { MEASUREMENT_SHORT } from "utils/productUtils";
 import { matchesSearch } from "utils/stringUtils";
@@ -240,7 +240,7 @@ export const WarehouseMovementsTab: React.FC<WarehouseMovementsTabProps> = ({ mo
 												component="span"
 												sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 											>
-												{formatDate(movement.date)}
+												{formatDateTime(movement.date)}
 											</Box>
 										</td>
 										<td>

--- a/src/i18n/ru/employee.json
+++ b/src/i18n/ru/employee.json
@@ -92,7 +92,7 @@
   "employee.action.restore": "Восстановить",
 
   "employee.table.employee": "Сотрудник",
-  "employee.table.salary": "Зарплата, UZS",
+  "employee.table.salary": "Зарплата",
 
   "employee.empty.title": "Пока нет сотрудников",
   "employee.empty.body": "Добавьте сотрудника, чтобы вести учёт персонала и выплат зарплаты.",
@@ -113,7 +113,7 @@
   "employee.payroll.date": "Дата",
   "employee.payroll.type": "Тип",
   "employee.payroll.period": "Период",
-  "employee.payroll.amount": "Сумма, UZS",
+  "employee.payroll.amount": "Сумма",
   "employee.payroll.wallet": "Касса",
   "employee.payroll.salary": "Зарплата",
 

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -11,7 +11,7 @@
   "order.list.overdueTooltip": "Доставка просрочена",
   "order.col.customer": "Клиент",
   "order.col.positions": "Позиций",
-  "order.col.total": "Сумма, UZS",
+  "order.col.total": "Сумма",
   "order.col.delivery": "Доставка",
   "order.col.status": "Статус",
   "order.col.source": "Источник",

--- a/src/i18n/ru/partner.json
+++ b/src/i18n/ru/partner.json
@@ -23,7 +23,7 @@
 
   "partner.table.name": "Имя партнёра",
   "partner.table.type": "Тип",
-  "partner.table.balance": "Баланс, UZS",
+  "partner.table.balance": "Баланс",
   "partner.table.company": "Компания",
   "partner.table.phone": "Телефон",
 
@@ -120,7 +120,7 @@
   "partner.txns.col.type": "Тип",
   "partner.txns.col.number": "Номер",
   "partner.txns.col.positions": "Позиций",
-  "partner.txns.col.amount": "Сумма, UZS",
+  "partner.txns.col.amount": "Сумма",
   "partner.txns.col.status": "Статус оплаты",
   "partner.txns.empty.title": "Нет записей",
   "partner.txns.empty.body": "С этим партнёром ещё не было продаж, поставок или возвратов.",
@@ -135,7 +135,7 @@
   "partner.pays.col.date": "Дата",
   "partner.pays.col.type": "Тип",
   "partner.pays.col.method": "Способ",
-  "partner.pays.col.amount": "Сумма, UZS",
+  "partner.pays.col.amount": "Сумма",
   "partner.pays.col.allocation": "Распределение",
   "partner.pays.col.wallet": "Касса",
   "partner.pays.advance": "Аванс",

--- a/src/i18n/ru/payment.json
+++ b/src/i18n/ru/payment.json
@@ -79,7 +79,7 @@
   "payment.table.direction": "Направление",
   "payment.table.party": "Партнёр / Сотрудник",
   "payment.table.wallet": "Касса",
-  "payment.table.amount": "Сумма, UZS",
+  "payment.table.amount": "Сумма",
 
   "payment.empty.title": "Пока нет платежей",
   "payment.empty.body": "Проведите первый платёж — оплату, депозит, вывод, зарплату или общий расход.",

--- a/src/i18n/ru/template.json
+++ b/src/i18n/ru/template.json
@@ -12,7 +12,7 @@
   "template.table.type": "Тип",
   "template.table.partner": "Партнёр",
   "template.table.positions": "Позиций",
-  "template.table.total": "Сумма, UZS",
+  "template.table.total": "Сумма",
   "template.table.lastUsed": "Использован",
 
   "template.itemsTable.product": "Товар",
@@ -20,7 +20,7 @@
   "template.itemsTable.quantity": "Кол-во",
   "template.itemsTable.unit": "Ед.",
   "template.itemsTable.unitPrice": "Цена за ед.",
-  "template.itemsTable.lineTotal": "Итого, UZS",
+  "template.itemsTable.lineTotal": "Итого",
   "template.itemsTable.footer": "Итого · {{count}} {{word}}",
 
   "template.empty.title": "Шаблоны пока не созданы",

--- a/src/i18n/ru/transaction.json
+++ b/src/i18n/ru/transaction.json
@@ -99,7 +99,7 @@
   "transaction.col.type": "Тип",
   "transaction.col.partner": "Партнёр",
   "transaction.col.positions": "Позиций",
-  "transaction.col.amount": "Сумма, UZS",
+  "transaction.col.amount": "Сумма",
   "transaction.col.status": "Статус оплаты",
 
   "transaction.badge.base.Sale": "Продажа",

--- a/src/i18n/ru/wallet.json
+++ b/src/i18n/ru/wallet.json
@@ -31,7 +31,7 @@
 
   "wallet.table.name": "Касса",
   "wallet.table.type": "Тип",
-  "wallet.table.balance": "Баланс, UZS",
+  "wallet.table.balance": "Баланс",
   "wallet.table.advances": "Авансы партнёров",
   "wallet.table.ourMoney": "Наши средства",
   "wallet.table.status": "Статус",

--- a/src/pages/EmployeeDetailPage.tsx
+++ b/src/pages/EmployeeDetailPage.tsx
@@ -17,7 +17,7 @@ import { PaymentRecord } from "models/payment";
 import { PATHS } from "routing/paths";
 import { useStore } from "stores/StoreContext";
 import { designTokens, numericSx } from "theme";
-import { formatDate, PresetOption } from "utils/dateUtils";
+import { formatDate, formatDateTime, PresetOption } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
 
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
@@ -127,7 +127,7 @@ const EmployeeDetailPage: React.FC = observer(() => {
 						component="span"
 						sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 					>
-						{formatDate(p.date)}
+						{formatDateTime(p.date)}
 					</Box>
 				),
 			},


### PR DESCRIPTION
Part of the G7 UI-conventions rollout (`issues-tracker.md` §5). First themed branch off `redesign/issue-fixes`.

## XC-4 — money headers drop «, UZS»
The 11 money column headers now read «Сумма» / «Баланс» / «Итого» / «Зарплата» (owner decision, ui-patterns Display conventions). Inline `UZS` unit-suffixes on card *values* are unchanged (out of scope).

## XC-5 — date + time on event columns
Every event/timestamp column now renders «07.07.2026 16:33» (space separator) via the shared `formatDateTime`: payments (list + detail), sales/supplies, orders, transfers, adjustments, wallet operations/transfers, partner ledger/transactions/payments, warehouse & product movements/transactions, employee payroll, debts. Two duplicated ad-hoc `timeOf` helpers and the split `tx.time` rendering were retired. CSV exports and pure calendar dates (hire / delivery / opening) stay date-only.

## XC-2 — sortable columns
- Added `sortValue`/`field` to the previously-unsortable columns in the categories (`productCount`) and transfers (from/to/positions/units/createdBy) configs.
- Wired the five hand-rolled detail tabs — partner ledger/transactions/payments, product movements/transactions — to sort via `DetailSortHeader`, which gained an optional `sx` prop so it fits the per-cell `headCellSx` tables. The product opening-balance row derives the oldest movement by date (stable under sort); the partner ledger keeps its served per-row running balance.

## Verification
`npm run validate` clean (0 errors). Live-verified on :3000: payments/partner-ledger headers read «Сумма»; dates show date+time; transfers columns are sortable; clicking the partner-ledger «Дата» header toggles desc↔asc and reorders while each row keeps its served running balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable columns to ledger, payment, transaction, product movement, and product transaction tables.
  * Improved sorting consistency for transfer table columns.
* **Improvements**
  * Date and time values now display together consistently across operational, financial, order, product, and warehouse views.
  * Updated table headers to support customized styling.
  * Simplified Russian currency labels by removing redundant currency suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->