### PR TITLE
G7 detail nav: history back, shared wallet action menu, entity links (XC-13/6/8)

### DIFF
--- a/src/components/product/Detail/ProductTransactionsTab.tsx
+++ b/src/components/product/Detail/ProductTransactionsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import PartnerLink from "components/partner/Links/PartnerLink";
 import DetailCard from "components/shared/Detail/DetailCard";
 import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
 import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
@@ -144,7 +145,9 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 									<td>
 										<TransactionKindChip kind={txn.transactionType} />
 									</td>
-									<td>{txn.partnerName}</td>
+									<td>
+										<PartnerLink id={txn.partnerId} name={txn.partnerName} />
+									</td>
 									<td className="r">
 										<Box component="span" sx={txn.quantity > 0 ? quantityInSx : quantityOutSx}>
 											{formatQuantity(Math.abs(txn.quantity))}

--- a/src/components/shared/Detail/DetailPageHeader.tsx
+++ b/src/components/shared/Detail/DetailPageHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import ActionMenu, { ActionMenuRow } from "components/shared/ActionMenuCell/MenuActionCell";
 import ArchivedBadge from "components/shared/ArchivedBadge/ArchivedBadge";
 import { designTokens } from "theme";
@@ -9,7 +9,8 @@ import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { Box, ButtonBase, Typography } from "@mui/material";
 
 interface DetailPageHeaderProps {
-	/** Parent list route the back button returns to. */
+	/** Fallback list route for the back button — used only on a direct load / deep
+	 *  link (no in-app history); otherwise back returns to the previous page. */
 	backTo: string;
 	/** The entity name — the title shows the name only (other fields live in the summary). */
 	title: string;
@@ -50,6 +51,10 @@ export const DetailPageHeader: React.FC<DetailPageHeaderProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const location = useLocation();
+	// Back returns to the previous page; on a direct load / deep link (no in-app
+	// history, so `key` is the router default) it falls back to the list route.
+	const goBack = () => (location.key === "default" ? navigate(backTo) : navigate(-1));
 
 	return (
 		<Box
@@ -63,7 +68,7 @@ export const DetailPageHeader: React.FC<DetailPageHeaderProps> = ({
 		>
 			<Box sx={{ display: "flex", alignItems: "center", gap: "14px", minWidth: 0 }}>
 				<ButtonBase
-					onClick={() => navigate(backTo)}
+					onClick={goBack}
 					aria-label={t("common.back")}
 					sx={{
 						width: 40,

--- a/src/components/transfer/Table/transfersTableConfigs.tsx
+++ b/src/components/transfer/Table/transfersTableConfigs.tsx
@@ -1,4 +1,5 @@
 import { Column } from "components/shared/Table/DataTable/DataTable";
+import WarehouseLink from "components/warehouse/Links/WarehouseLink";
 import { TFunction } from "i18next";
 import { Transfer, transferUnits } from "models/transfer";
 import { designTokens, numericSx } from "theme";
@@ -9,7 +10,13 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import WarehouseOutlinedIcon from "@mui/icons-material/WarehouseOutlined";
 import { Box, Typography } from "@mui/material";
 
-const WarehouseCell: React.FC<{ name: string; accent?: boolean }> = ({ name, accent }) => (
+const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+const WarehouseCell: React.FC<{ id: number; name: string; accent?: boolean }> = ({
+	id,
+	name,
+	accent,
+}) => (
 	<Box
 		component="span"
 		sx={{
@@ -17,14 +24,14 @@ const WarehouseCell: React.FC<{ name: string; accent?: boolean }> = ({ name, acc
 			alignItems: "center",
 			gap: "7px",
 			whiteSpace: "nowrap",
-			color: accent ? "primary.main" : "text.secondary",
 			fontWeight: accent ? 600 : 400,
 		}}
+		onClick={stop}
 	>
 		<WarehouseOutlinedIcon
 			sx={{ fontSize: 15, color: accent ? "primary.main" : "text.disabled" }}
 		/>
-		{name}
+		<WarehouseLink id={id} name={name} />
 	</Box>
 );
 
@@ -55,14 +62,18 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			headerName: t("transfer.table.from"),
 			width: "22%",
 			sortValue: (transfer) => transfer.fromWarehouseName,
-			renderCell: (transfer) => <WarehouseCell name={transfer.fromWarehouseName} />,
+			renderCell: (transfer) => (
+				<WarehouseCell id={transfer.fromWarehouseId} name={transfer.fromWarehouseName} />
+			),
 		},
 		{
 			key: "to",
 			headerName: t("transfer.table.to"),
 			width: "22%",
 			sortValue: (transfer) => transfer.toWarehouseName,
-			renderCell: (transfer) => <WarehouseCell name={transfer.toWarehouseName} accent />,
+			renderCell: (transfer) => (
+				<WarehouseCell id={transfer.toWarehouseId} name={transfer.toWarehouseName} accent />
+			),
 		},
 		{
 			key: "positions",

--- a/src/components/wallet/Detail/WalletDetailHeader.tsx
+++ b/src/components/wallet/Detail/WalletDetailHeader.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
+import ActionMenu, { ActionMenuRow } from "components/shared/ActionMenuCell/MenuActionCell";
 import ArchivedBadge from "components/shared/ArchivedBadge/ArchivedBadge";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { WalletTypeBadge } from "components/wallet/WalletPresentation";
@@ -12,18 +13,8 @@ import AddIcon from "@mui/icons-material/Add";
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import UnarchiveOutlinedIcon from "@mui/icons-material/UnarchiveOutlined";
-import {
-	Box,
-	ButtonBase,
-	IconButton,
-	ListItemIcon,
-	ListItemText,
-	Menu,
-	MenuItem,
-	Typography,
-} from "@mui/material";
+import { Box, ButtonBase, Typography } from "@mui/material";
 
 interface WalletDetailHeaderProps {
 	wallet: Wallet;
@@ -34,67 +25,12 @@ interface WalletDetailHeaderProps {
 	onRestore: () => void;
 }
 
-/** Bordered ⋮ trigger + entity actions (locked pattern 2). */
-const DetailActionsMenu: React.FC<{ onEdit: () => void; onArchive: () => void }> = ({
-	onEdit,
-	onArchive,
-}) => {
-	const { t } = useTranslation();
-	const [anchor, setAnchor] = useState<HTMLElement | null>(null);
-	const close = () => setAnchor(null);
-
-	return (
-		<>
-			<IconButton
-				onClick={(e) => setAnchor(e.currentTarget)}
-				aria-label="actions"
-				sx={{
-					width: 38,
-					height: 38,
-					borderRadius: "8px",
-					border: "1px solid",
-					borderColor: designTokens.gray300,
-					color: designTokens.gray600,
-				}}
-			>
-				<MoreVertIcon sx={{ fontSize: 20 }} />
-			</IconButton>
-			<Menu anchorEl={anchor} open={Boolean(anchor)} onClose={close}>
-				<MenuItem
-					onClick={() => {
-						close();
-						onEdit();
-					}}
-				>
-					<ListItemIcon>
-						<EditOutlinedIcon fontSize="small" sx={{ color: "text.secondary" }} />
-					</ListItemIcon>
-					<ListItemText primary={t("common.edit")} />
-				</MenuItem>
-				<MenuItem
-					onClick={() => {
-						close();
-						onArchive();
-					}}
-				>
-					<ListItemIcon>
-						<ArchiveOutlinedIcon fontSize="small" sx={{ color: designTokens.saffron600 }} />
-					</ListItemIcon>
-					<ListItemText
-						primary={t("common.archive")}
-						slotProps={{ primary: { sx: { color: designTokens.saffron700 } } }}
-					/>
-				</MenuItem>
-			</Menu>
-		</>
-	);
-};
-
 /**
  * Wallet detail header per the bundle: bordered back chevron, title with the
- * type + archive badges, the «Начальный остаток · создана»
- * meta row, and either the ⋮ actions menu (edit / archive) or a primary
- * «Восстановить» when archived (locked pattern 2).
+ * type + archive badges, the «Начальный остаток · создана» meta row, and either
+ * the shared ⋮ actions menu (edit / archive) or a primary «Восстановить» when
+ * archived (locked pattern 2). The ⋮ uses the shared bordered `ActionMenu`
+ * (kills the hand-rolled menu + hardcoded aria-label, CR A-FE-12).
  */
 export const WalletDetailHeader: React.FC<WalletDetailHeaderProps> = ({
 	wallet,
@@ -106,76 +42,91 @@ export const WalletDetailHeader: React.FC<WalletDetailHeaderProps> = ({
 }) => {
 	const { t } = useTranslation();
 
+	const actions: ActionMenuRow[] = [
+		{
+			key: "edit",
+			label: t("common.edit"),
+			icon: <EditOutlinedIcon fontSize="small" sx={{ color: "text.secondary" }} />,
+			onClick: onEdit,
+		},
+		{
+			key: "archive",
+			label: t("common.archive"),
+			labelColor: designTokens.saffron700,
+			dividerBefore: true,
+			icon: <ArchiveOutlinedIcon fontSize="small" sx={{ color: designTokens.saffron600 }} />,
+			onClick: onArchive,
+		},
+	];
+
 	return (
-		<>
-			<Box
-				sx={{
-					display: "flex",
-					alignItems: "flex-start",
-					justifyContent: "space-between",
-					gap: "20px",
-					mb: "22px",
-				}}
-			>
-				<Box sx={{ display: "flex", alignItems: "center", gap: "14px", minWidth: 0 }}>
-					<ButtonBase
-						onClick={onBack}
-						aria-label={t("wallet.detail.back")}
-						sx={{
-							width: 40,
-							height: 40,
-							flex: "0 0 auto",
-							borderRadius: "8px",
-							border: "1px solid",
-							borderColor: designTokens.gray300,
-							bgcolor: "background.paper",
-							color: designTokens.gray700,
-							"&:hover": { bgcolor: designTokens.gray50, borderColor: designTokens.gray400 },
-						}}
-					>
-						<ChevronLeftIcon sx={{ fontSize: 20 }} />
-					</ButtonBase>
+		<Box
+			sx={{
+				display: "flex",
+				alignItems: "flex-start",
+				justifyContent: "space-between",
+				gap: "20px",
+				mb: "22px",
+			}}
+		>
+			<Box sx={{ display: "flex", alignItems: "center", gap: "14px", minWidth: 0 }}>
+				<ButtonBase
+					onClick={onBack}
+					aria-label={t("wallet.detail.back")}
+					sx={{
+						width: 40,
+						height: 40,
+						flex: "0 0 auto",
+						borderRadius: "8px",
+						border: "1px solid",
+						borderColor: designTokens.gray300,
+						bgcolor: "background.paper",
+						color: designTokens.gray700,
+						"&:hover": { bgcolor: designTokens.gray50, borderColor: designTokens.gray400 },
+					}}
+				>
+					<ChevronLeftIcon sx={{ fontSize: 20 }} />
+				</ButtonBase>
 
-					<Box sx={{ minWidth: 0 }}>
-						<Box sx={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap" }}>
-							<Typography
-								component="h1"
-								sx={{ fontSize: 24, fontWeight: 700, letterSpacing: "-0.02em", lineHeight: 1.25 }}
-							>
-								{wallet.name}
-							</Typography>
-							<WalletTypeBadge type={wallet.type} />
-							{wallet.isArchived && <ArchivedBadge />}
-						</Box>
-						<Typography sx={{ fontSize: 13, color: "text.secondary", mt: "6px" }}>
-							{t("wallet.detail.openingLabel")}{" "}
-							<Box component="span" sx={numericSx}>
-								{formatCurrency(wallet.openingBalance)}
-							</Box>{" "}
-							UZS · {t("wallet.detail.createdLabel")} {formatDate(wallet.createdAt)} ·{" "}
-							{wallet.createdBy}
+				<Box sx={{ minWidth: 0 }}>
+					<Box sx={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap" }}>
+						<Typography
+							component="h1"
+							sx={{ fontSize: 24, fontWeight: 700, letterSpacing: "-0.02em", lineHeight: 1.25 }}
+						>
+							{wallet.name}
 						</Typography>
+						<WalletTypeBadge type={wallet.type} />
+						{wallet.isArchived && <ArchivedBadge />}
 					</Box>
-				</Box>
-
-				<Box sx={{ display: "flex", alignItems: "center", gap: "10px", flex: "0 0 auto" }}>
-					{wallet.isArchived ? (
-						<PrimaryButton icon={<UnarchiveOutlinedIcon />} onClick={onRestore}>
-							{t("common.restore")}
-						</PrimaryButton>
-					) : (
-						<>
-							{/* Child-event create in the primaryAction slot (WAL-13) — reachable
-							    from both tabs, next to the ⋮ menu (Order-detail pattern). */}
-							<PrimaryButton icon={<AddIcon />} onClick={onNewTransfer}>
-								{t("wallet.transfer.action")}
-							</PrimaryButton>
-							<DetailActionsMenu onEdit={onEdit} onArchive={onArchive} />
-						</>
-					)}
+					<Typography sx={{ fontSize: 13, color: "text.secondary", mt: "6px" }}>
+						{t("wallet.detail.openingLabel")}{" "}
+						<Box component="span" sx={numericSx}>
+							{formatCurrency(wallet.openingBalance)}
+						</Box>{" "}
+						UZS · {t("wallet.detail.createdLabel")} {formatDate(wallet.createdAt)} ·{" "}
+						{wallet.createdBy}
+					</Typography>
 				</Box>
 			</Box>
-		</>
+
+			<Box sx={{ display: "flex", alignItems: "center", gap: "10px", flex: "0 0 auto" }}>
+				{wallet.isArchived ? (
+					<PrimaryButton icon={<UnarchiveOutlinedIcon />} onClick={onRestore}>
+						{t("common.restore")}
+					</PrimaryButton>
+				) : (
+					<>
+						{/* Child-event create in the primaryAction slot (WAL-13) — reachable
+						    from both tabs, next to the ⋮ menu (Order-detail pattern). */}
+						<PrimaryButton icon={<AddIcon />} onClick={onNewTransfer}>
+							{t("wallet.transfer.action")}
+						</PrimaryButton>
+						<ActionMenu bordered actions={actions} />
+					</>
+				)}
+			</Box>
+		</Box>
 	);
 };
 

--- a/src/components/wallet/Detail/WalletTransfersTab.tsx
+++ b/src/components/wallet/Detail/WalletTransfersTab.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import GhostButton from "components/shared/Buttons/GhostButton";
 import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
+import WalletLink from "components/wallet/Links/WalletLink";
 import { WalletTypeAvatar } from "components/wallet/WalletPresentation";
 import { WalletTransfer } from "models/wallet";
 import { numericSx } from "theme";
@@ -19,13 +20,20 @@ interface WalletTransfersTabProps {
 	onOpenTransfer: (transferId: number) => void;
 }
 
-const WalletCell: React.FC<{ name: string; type: WalletTransfer["fromWalletType"] }> = ({
-	name,
-	type,
-}) => (
-	<Box sx={{ display: "inline-flex", alignItems: "center", gap: "8px", fontWeight: 600 }}>
+const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+const WalletCell: React.FC<{
+	id: number;
+	name: string;
+	type: WalletTransfer["fromWalletType"];
+}> = ({ id, name, type }) => (
+	<Box
+		component="span"
+		sx={{ display: "inline-flex", alignItems: "center", gap: "8px", fontWeight: 600 }}
+		onClick={stop}
+	>
 		<WalletTypeAvatar type={type} size={24} iconSize={14} />
-		{name}
+		<WalletLink id={id} name={name} />
 	</Box>
 );
 
@@ -61,13 +69,17 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 				key: "from",
 				headerName: t("wallet.transfers.from"),
 				sortValue: (tr) => tr.fromWalletName,
-				renderCell: (tr) => <WalletCell name={tr.fromWalletName} type={tr.fromWalletType} />,
+				renderCell: (tr) => (
+					<WalletCell id={tr.fromWalletId} name={tr.fromWalletName} type={tr.fromWalletType} />
+				),
 			},
 			{
 				key: "to",
 				headerName: t("wallet.transfers.to"),
 				sortValue: (tr) => tr.toWalletName,
-				renderCell: (tr) => <WalletCell name={tr.toWalletName} type={tr.toWalletType} />,
+				renderCell: (tr) => (
+					<WalletCell id={tr.toWalletId} name={tr.toWalletName} type={tr.toWalletType} />
+				),
 			},
 			{
 				key: "amount",

--- a/src/pages/EmployeeDetailPage.tsx
+++ b/src/pages/EmployeeDetailPage.tsx
@@ -10,6 +10,7 @@ import ConfirmDialog from "components/shared/Dialog/ConfirmDialog/ConfirmDialog"
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { SegmentedControl } from "components/shared/SegmentedControl/SegmentedControl";
 import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
+import WalletLink from "components/wallet/Links/WalletLink";
 import { EmployeeFormPayload } from "hooks/employee/useEmployeeForm";
 import { PayrollFormPayload } from "hooks/payroll/usePayrollForm";
 import { observer } from "mobx-react-lite";
@@ -178,11 +179,14 @@ const EmployeeDetailPage: React.FC = observer(() => {
 				key: "wallet",
 				headerName: t("employee.payroll.wallet"),
 				sortValue: (p) => p.walletName ?? "",
-				renderCell: (p) => (
-					<Box component="span" sx={{ color: designTokens.gray700 }}>
-						{p.walletName || "—"}
-					</Box>
-				),
+				renderCell: (p) =>
+					p.walletName ? (
+						<WalletLink id={p.walletId} name={p.walletName} />
+					) : (
+						<Box component="span" sx={{ color: designTokens.gray700 }}>
+							—
+						</Box>
+					),
 			},
 		],
 		[t],

--- a/src/pages/WalletDetailPage.tsx
+++ b/src/pages/WalletDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import ConfirmDialog from "components/shared/Dialog/ConfirmDialog/ConfirmDialog";
 import WalletArchivedBanner from "components/wallet/Detail/WalletArchivedBanner";
 import WalletDetailHeader from "components/wallet/Detail/WalletDetailHeader";
@@ -24,6 +24,7 @@ import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 const WalletDetailPage: React.FC = observer(() => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { id } = useParams<{ id: string }>();
 	const walletId = Number(id);
 	const { walletStore, selectedWalletStore, notificationStore } = useStore();
@@ -40,7 +41,7 @@ const WalletDetailPage: React.FC = observer(() => {
 		return () => selectedWalletStore.clear();
 	}, [walletId, selectedWalletStore, walletStore]);
 
-	const goBack = () => navigate(PATHS.wallets);
+	const goBack = () => (location.key === "default" ? navigate(PATHS.wallets) : navigate(-1));
 
 	const wallet = selectedWalletStore.wallet;
 	const dialogMode = walletStore.dialogMode;


### PR DESCRIPTION
Second G7 branch, **stacked on `redesign/issue-table-conventions`** (PR #74) — review/merge that first, then this retargets to `redesign/issue-fixes`.

## XC-13 — back button = history
Detail-page back now returns to the *previous page* rather than always jumping to the list root. `DetailPageHeader` uses `navigate(-1)`, falling back to the `backTo` list route only on a direct load / deep link (`location.key === "default"`). Same logic applied to the bespoke `WalletDetailPage` back handler; the partner post-**delete** redirect stays a hardcoded list path.

## XC-6 — shared ActionMenu on the wallet detail header
Replaces the hand-rolled `DetailActionsMenu` (hardcoded `aria-label="actions"`, CR A-FE-12) with the shared bordered `ActionMenu`, matching the wallet list menu (edit + saffron archive) and the localized «Действия» aria-label. This was the last module still hand-rolling a detail menu.

## XC-8 — entity links in cells
Plain-text entity names wrapped in the existing `*Link` wrappers (with `stopPropagation` on clickable rows): transfer list from/to warehouses, wallet-transfers from/to wallets, product-detail transactions partner, employee payroll wallet.

**Deliberately not linked** (id not served — known gaps, not stubbed): the partner column in wallet operations (WAL-7, no `partnerId`) and the wallet column in the partner payments tab (no `walletId`). The sale/supply-detail warehouse + transfer-detail-modal links are left to the transactions/transfers module passes.

## Verification
`npm run validate` clean. Live on :3000: deep-link `/wallets/1` → Back falls back to `/wallets`; `/payments` → partner link → `/partners/23` → Back returns to `/payments` (previous page, the XC-13 improvement); wallet header ⋮ is the shared «Действия» menu; transfers from/to render as `/warehouses/:id` links.