### PR TITLE
G7 form conventions: Enter/Ctrl+Enter submit + helper-text sweep (XC-11/12)

### DIFF
--- a/docs/shared-components.md
+++ b/docs/shared-components.md
@@ -52,6 +52,7 @@
 | `PartnerPicker`                                                        | Partner selection with balance as color + label | Lives in `components/transaction/Create/`; reused by New Order                     |
 | `ProductSearchBar`                                                     | Product-search cart feeder (POS flows)          | Lives in `components/transaction/Create/`; reused by New Order                     |
 | `useDirtyClose` (hook)                                                 | Unsaved-changes guard on modals                 | Lives in `hooks/shared/`                                                            |
+| `useFormKeyboardSubmit` (hook)                                         | Enter / Ctrl+Enter submit on form modals (XC-11) | Lives in `hooks/shared/`; returns an `onKeyDown` for the modal `<Dialog>`           |
 
 ## Buttons
 

--- a/src/components/category/Form/CategoryFormModal.tsx
+++ b/src/components/category/Form/CategoryFormModal.tsx
@@ -5,6 +5,7 @@ import FormDialogFooter from "components/shared/Dialog/Form/FormDialogFooter";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import { CategoryFormPayload, useCategoryForm } from "hooks/category/useCategoryForm";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { Category } from "models/category";
 import { dialogTranslation } from "utils/translationUtils";
 
@@ -28,6 +29,7 @@ const CategoryFormModal: React.FC<CategoryFormModalProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const { form, canSave, submit } = useCategoryForm({ isOpen, isSaving, category, onSave });
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 
 	const { discardOpen, requestClose, cancelDiscard, confirmDiscard } = useDirtyClose(
 		form.formState.isDirty,
@@ -51,6 +53,7 @@ const CategoryFormModal: React.FC<CategoryFormModalProps> = ({
 				maxWidth="sm"
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 			>
 				<FormDialogHeader title={title} onClose={requestClose} disabled={isSaving} />
 
@@ -83,7 +86,7 @@ const CategoryFormModal: React.FC<CategoryFormModalProps> = ({
 						maxRows={6}
 						disabled={isSaving}
 						error={!!errors.description}
-						helperText={errors.description?.message ?? t("category.form.descriptionHint")}
+						helperText={errors.description?.message}
 						{...register("description")}
 					/>
 				</DialogContent>

--- a/src/components/employee/Form/EmployeeFormModal.tsx
+++ b/src/components/employee/Form/EmployeeFormModal.tsx
@@ -5,6 +5,7 @@ import ConfirmDialog from "components/shared/Dialog/ConfirmDialog/ConfirmDialog"
 import FormDialogFooter from "components/shared/Dialog/Form/FormDialogFooter";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import { EmployeeFormPayload, useEmployeeForm } from "hooks/employee/useEmployeeForm";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { Employee } from "models/employee";
 import { dialogTranslation } from "utils/translationUtils";
 
@@ -35,6 +36,8 @@ const EmployeeFormModal: React.FC<EmployeeFormModalProps> = ({
 			onClose,
 		});
 
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
+
 	const title = employee ? t("employee.editTitle") : t("employee.createTitle");
 
 	return (
@@ -46,6 +49,7 @@ const EmployeeFormModal: React.FC<EmployeeFormModalProps> = ({
 				fullWidth
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 			>
 				<FormDialogHeader title={title} onClose={requestClose} disabled={isSaving} />
 

--- a/src/components/partner/Detail/LedgerTab.tsx
+++ b/src/components/partner/Detail/LedgerTab.tsx
@@ -10,7 +10,6 @@ import { balanceColor } from "utils/partnerUtils";
 
 import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
 import FilterListIcon from "@mui/icons-material/FilterList";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Box } from "@mui/material";
 
@@ -166,20 +165,6 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 					−
 				</Box>
 				{t("partner.ledger.legendNeg")}
-			</Box>
-			<Box sx={{ flexGrow: 1 }} />
-			<Box
-				component="span"
-				sx={{
-					display: "inline-flex",
-					alignItems: "center",
-					gap: "6px",
-					fontWeight: 600,
-					color: "text.secondary",
-				}}
-			>
-				<InfoOutlinedIcon sx={{ fontSize: 14, color: "info.main" }} />
-				{t("partner.ledger.legendBalance")}
 			</Box>
 		</Box>
 	);

--- a/src/components/partner/Form/PartnerFormModal.tsx
+++ b/src/components/partner/Form/PartnerFormModal.tsx
@@ -9,6 +9,7 @@ import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import SegmentedControl from "components/shared/SegmentedControl/SegmentedControl";
 import { usePartnerForm } from "hooks/partner/usePartnerForm";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { Partner, PartnerType } from "models/partner";
 import { PartnerFormValues } from "schemas/PartnerSchema";
 import { designTokens, numericSx } from "theme";
@@ -81,6 +82,7 @@ const PartnerFormModal: React.FC<PartnerFormModalProps> = ({
 		},
 	);
 	const { control, formState, watch } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 	const { errors, isSubmitted } = formState;
 
 	const openingType = watch("openingType");
@@ -101,6 +103,7 @@ const PartnerFormModal: React.FC<PartnerFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 620, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/payment/Form/PaymentCreateModal.tsx
+++ b/src/components/payment/Form/PaymentCreateModal.tsx
@@ -11,6 +11,7 @@ import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { SegmentedControl } from "components/shared/SegmentedControl/SegmentedControl";
 import { autoDirection, usePaymentForm } from "hooks/payment/usePaymentForm";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { observer } from "mobx-react-lite";
 import {
 	CreatePaymentRecordRequest,
@@ -195,6 +196,8 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 		});
 	});
 
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
+
 	const fieldError = (name: keyof PaymentFormValues): string | undefined =>
 		(formState.errors[name]?.message as string | undefined) ?? undefined;
 
@@ -205,6 +208,7 @@ const PaymentCreateModal: React.FC<PaymentCreateModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 720, maxWidth: "96%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/payroll/Form/PayrollFormModal.tsx
+++ b/src/components/payroll/Form/PayrollFormModal.tsx
@@ -6,6 +6,7 @@ import ConfirmDialog from "components/shared/Dialog/ConfirmDialog/ConfirmDialog"
 import FormDialogFooter from "components/shared/Dialog/Form/FormDialogFooter";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import { PayrollFormMode, PayrollFormPayload, usePayrollForm } from "hooks/payroll/usePayrollForm";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { observer } from "mobx-react-lite";
 import { dialogTranslation } from "utils/translationUtils";
 
@@ -45,6 +46,8 @@ const PayrollFormModal: React.FC<PayrollFormModalProps> = observer(
 			onClose,
 		});
 
+		const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
+
 		const title = t("payroll.createTitle");
 
 		return (
@@ -56,6 +59,7 @@ const PayrollFormModal: React.FC<PayrollFormModalProps> = observer(
 					fullWidth
 					disableEscapeKeyDown={isSaving}
 					disableRestoreFocus
+					onKeyDown={onKeyDown}
 				>
 					<FormDialogHeader title={title} onClose={requestClose} disabled={isSaving} />
 

--- a/src/components/product/Form/ProductFormModal.tsx
+++ b/src/components/product/Form/ProductFormModal.tsx
@@ -5,6 +5,7 @@ import FormDialogFooter from "components/shared/Dialog/Form/FormDialogFooter";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import { useProductForm } from "hooks/product/useProductForm";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { observer } from "mobx-react-lite";
 import { Product } from "models/product";
 import { ProductFormValues } from "schemas/ProductSchema";
@@ -38,6 +39,7 @@ const ProductFormModal: React.FC<ProductFormModalProps> = ({
 	const { categoryStore } = useStore();
 
 	const form = useProductForm({ isOpen, isSaving, product, onSave });
+	const onKeyDown = useFormKeyboardSubmit(form.submit, isSaving);
 
 	const { discardOpen, requestClose, cancelDiscard, confirmDiscard } = useDirtyClose(
 		form.formState.isDirty,
@@ -74,6 +76,7 @@ const ProductFormModal: React.FC<ProductFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{
 					// Bundle .fcard/.prod-dialog: 720px wide, r-lg corners.
 					paper: { sx: { width: 720, maxWidth: "94%", borderRadius: "12px" } },

--- a/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
+++ b/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
@@ -8,6 +8,7 @@ import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import NumericField from "components/shared/Inputs/NumericField";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { useStockAdjustmentForm } from "hooks/stockAdjustment/useStockAdjustmentForm";
 import { observer } from "mobx-react-lite";
 import { Product } from "models/product";
@@ -261,6 +262,7 @@ const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({
 		onSave: guardedSave,
 	});
 	const { control, setValue, formState, watch } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 
 	const warehouseId = watch("warehouseId");
 	const direction = watch("direction") as AdjustmentDirection;
@@ -325,6 +327,7 @@ const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 600, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/template/Modal/TemplateFormModal.tsx
+++ b/src/components/template/Modal/TemplateFormModal.tsx
@@ -10,6 +10,7 @@ import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import NumericField from "components/shared/Inputs/NumericField";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { TemplateFormPayload, useTemplateForm } from "hooks/templates/useTemplateForm";
 import { observer } from "mobx-react-lite";
 import { Partner } from "models/partner";
@@ -209,6 +210,7 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
 		submit,
 	} = useTemplateForm({ isOpen, isSaving, template, onSave, onClose });
 	const { control, formState, watch, setValue } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 
 	const partnerId = watch("partnerId");
 	const watchedItems = watch("items");
@@ -254,6 +256,7 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 760, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/transfer/Form/TransferFormModal.tsx
+++ b/src/components/transfer/Form/TransferFormModal.tsx
@@ -9,6 +9,7 @@ import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import NumericField from "components/shared/Inputs/NumericField";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { emptyLine, useTransferForm } from "hooks/transfer/useTransferForm";
 import { observer } from "mobx-react-lite";
 import { Product } from "models/product";
@@ -92,6 +93,7 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 		onSave: guardedSave,
 	});
 	const { control, setValue, formState, watch } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 
 	const fromWarehouseId = watch("fromWarehouseId");
 	const toWarehouseId = watch("toWarehouseId");
@@ -163,6 +165,7 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 680, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/wallet/Form/WalletFormModal.tsx
+++ b/src/components/wallet/Form/WalletFormModal.tsx
@@ -8,6 +8,7 @@ import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import MoneyField from "components/shared/Inputs/MoneyField";
 import { WALLET_TYPE_META } from "components/wallet/WalletPresentation";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { useWalletForm } from "hooks/wallet/useWalletForm";
 import { observer } from "mobx-react-lite";
 import { Wallet, WALLET_TYPES, WalletType } from "models/wallet";
@@ -140,6 +141,7 @@ const WalletFormModal: React.FC<WalletFormModalProps> = ({
 	const { t } = useTranslation();
 	const editing = Boolean(wallet);
 	const { form, canSave, submit } = useWalletForm({ isOpen, isSaving, wallet, onSave });
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 	const { control, formState } = form;
 
 	const { discardOpen, requestClose, cancelDiscard, confirmDiscard } = useDirtyClose(
@@ -155,6 +157,7 @@ const WalletFormModal: React.FC<WalletFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 520, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/wallet/Form/WalletTransferModal.tsx
+++ b/src/components/wallet/Form/WalletTransferModal.tsx
@@ -9,6 +9,7 @@ import MoneyField from "components/shared/Inputs/MoneyField";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { WalletTypeAvatar } from "components/wallet/WalletPresentation";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { useWalletTransferForm } from "hooks/wallet/useWalletTransferForm";
 import { observer } from "mobx-react-lite";
 import { Wallet } from "models/wallet";
@@ -146,6 +147,7 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 		onSave: guardedSave,
 	});
 	const { control, formState, watch, setValue } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 
 	const fromId = watch("fromWalletId");
 	const toId = watch("toWalletId");
@@ -179,6 +181,7 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 560, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/warehouse/Form/OpeningStockModal.tsx
+++ b/src/components/warehouse/Form/OpeningStockModal.tsx
@@ -10,6 +10,7 @@ import MoneyField from "components/shared/Inputs/MoneyField";
 import NumericField from "components/shared/Inputs/NumericField";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { emptyLine, useOpeningStockForm } from "hooks/warehouse/useOpeningStockForm";
 import { observer } from "mobx-react-lite";
 import { Product } from "models/product";
@@ -82,6 +83,7 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 		onSave: guardedSave,
 	});
 	const { control, formState, watch, setValue } = form;
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 	const watchedItems = watch("items");
 
 	const { discardOpen, requestClose, cancelDiscard, confirmDiscard } = useDirtyClose(
@@ -132,6 +134,7 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 760, maxWidth: "96%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/components/warehouse/Form/WarehouseFormModal.tsx
+++ b/src/components/warehouse/Form/WarehouseFormModal.tsx
@@ -6,6 +6,7 @@ import FormDialogFooter from "components/shared/Dialog/Form/FormDialogFooter";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
 import FormFieldLabel from "components/shared/Forms/FormFieldLabel";
 import { useDirtyClose } from "hooks/shared/useDirtyClose";
+import { useFormKeyboardSubmit } from "hooks/shared/useFormKeyboardSubmit";
 import { useWarehouseForm } from "hooks/warehouse/useWarehouseForm";
 import { observer } from "mobx-react-lite";
 import { Warehouse } from "models/warehouse";
@@ -31,6 +32,7 @@ const WarehouseFormModal: React.FC<WarehouseFormModalProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const { form, canSave, submit } = useWarehouseForm({ isOpen, isSaving, warehouse, onSave });
+	const onKeyDown = useFormKeyboardSubmit(submit, isSaving);
 	const { control, formState } = form;
 
 	const { discardOpen, requestClose, cancelDiscard, confirmDiscard } = useDirtyClose(
@@ -56,6 +58,7 @@ const WarehouseFormModal: React.FC<WarehouseFormModalProps> = ({
 				onClose={requestClose}
 				disableEscapeKeyDown={isSaving}
 				disableRestoreFocus
+				onKeyDown={onKeyDown}
 				slotProps={{ paper: { sx: { width: 520, maxWidth: "94%", borderRadius: "12px" } } }}
 			>
 				<FormDialogHeader

--- a/src/hooks/shared/useFormKeyboardSubmit.ts
+++ b/src/hooks/shared/useFormKeyboardSubmit.ts
@@ -1,0 +1,38 @@
+import { KeyboardEvent, useCallback } from "react";
+
+/**
+ * Keyboard submit for the form modals (XC-11). Attach the returned handler to the
+ * modal's `<Dialog onKeyDown={…}>`:
+ *
+ * - **Ctrl / Cmd + Enter** always submits — even from a textarea.
+ * - **Enter** submits from a single-line text input, but is left alone inside a
+ *   textarea (newline) or while an autocomplete / select popup is open on the
+ *   focused input (`aria-expanded="true"` — let it pick the option), and never
+ *   fires from a button (the browser already maps Enter to a click there).
+ *
+ * `disabled` (pass the form's `isSaving`) suppresses the shortcut while saving.
+ * IME composition (`isComposing`) is ignored so Enter can commit a candidate.
+ */
+export function useFormKeyboardSubmit(submit: () => void, disabled = false) {
+	return useCallback(
+		(event: KeyboardEvent<HTMLElement>) => {
+			if (disabled || event.key !== "Enter" || event.nativeEvent.isComposing) {
+				return;
+			}
+			if (event.metaKey || event.ctrlKey) {
+				event.preventDefault();
+				submit();
+				return;
+			}
+			const target = event.target as HTMLElement;
+			if (target.tagName !== "INPUT" || target.getAttribute("aria-expanded") === "true") {
+				return;
+			}
+			event.preventDefault();
+			submit();
+		},
+		[submit, disabled],
+	);
+}
+
+export default useFormKeyboardSubmit;

--- a/src/i18n/ru/category.json
+++ b/src/i18n/ru/category.json
@@ -16,7 +16,6 @@
   "category.form.namePlaceholder": "Введите название категории",
   "category.form.descriptionLabel": "Описание",
   "category.form.descriptionPlaceholder": "Краткое описание категории…",
-  "category.form.descriptionHint": "Помогает сотрудникам быстрее находить нужную категорию.",
 
   "category.validation.name.required": "Укажите название категории",
   "category.validation.name.tooLong": "Название не должно превышать 100 символов",

--- a/src/i18n/ru/partner.json
+++ b/src/i18n/ru/partner.json
@@ -93,7 +93,6 @@
   "partner.ledger.period.30": "30 дней",
   "partner.ledger.legendPos": "партнёр должен нам",
   "partner.ledger.legendNeg": "мы должны партнёру",
-  "partner.ledger.legendBalance": "Баланс после каждой операции",
   "partner.ledger.col.date": "Дата",
   "partner.ledger.col.event": "Событие",
   "partner.ledger.col.description": "Описание",


### PR DESCRIPTION
Third G7 branch, **stacked on `redesign/issue-detail-nav`** (PR #75 → #74). Review/merge the stack in order.

## XC-11 — keyboard submit on form modals (net-new)
New shared hook `hooks/shared/useFormKeyboardSubmit`:
- **Ctrl / Cmd + Enter** always submits (even from a textarea).
- **Enter** submits from a single-line input, but is left alone inside a textarea (newline), while an autocomplete/select popup is open on the focused input (`aria-expanded="true"` → pick the option), and on buttons (browser maps Enter → click there).
- Suppressed while `isSaving`; IME-composition safe.

Adopted as `<Dialog onKeyDown={…}>` across the **13 standard form modals**: category, warehouse, wallet, wallet-transfer, opening-stock, transfer, stock-adjustment, template, product, employee, payroll, partner, payment-create. Registered in `docs/shared-components.md`. Order / settlement / confirm modals keep their bespoke flows.

## XC-12 — helper-text sweep (first pass)
Removed the categories description hint and the partner-ledger «Баланс после каждой операции» legend note (these double as §6 items 2 and 8); pruned the two now-dead i18n keys (the unused `InfoOutlinedIcon` import auto-removed).

## Deferred (noted in commit + tracker)
The remaining XC-12 removals (adjustments immutability/overdraw, transfer-detail, partner-modal +/− & edit balance, templates footer, wallet-modal examples, initial-stock, movements) and **XC-16** (adjustments row → read-only modal) are a focused follow-up.

## Verification
`npm run validate` clean (0 errors). Live on :3000: pressing Enter on the empty required name field of the **category** and **warehouse** create modals fires submit (validation errors appear, nothing is created); the partner-ledger legend no longer shows the balance note while the +/− legend remains.