### PR TITLE
Module polish (first pass): product category star, movements count, remove transfer chevron & template subheader (§6)

### DIFF
--- a/src/components/product/Form/Fields/ProductCoreFields.tsx
+++ b/src/components/product/Form/Fields/ProductCoreFields.tsx
@@ -101,7 +101,7 @@ const ProductFormCoreFields: React.FC<ProductFormCoreFieldsProps> = ({
 					</Field>
 
 					<Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
-						<Field label={t("product.category")}>
+						<Field label={t("product.category")} required>
 							<Controller
 								name="categoryId"
 								control={control}

--- a/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
+++ b/src/components/stockAdjustment/Form/StockAdjustmentModal.tsx
@@ -478,7 +478,7 @@ const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({
 								quantity={quantity}
 								afterBalance={afterBalance}
 								overStock={overStock}
-								hasInput={selected != null && quantity > 0}
+								hasInput={selected != null}
 							/>
 							{overStock && (
 								<Typography

--- a/src/components/template/Header/TemplateHeader.tsx
+++ b/src/components/template/Header/TemplateHeader.tsx
@@ -47,7 +47,6 @@ const TemplateHeader: React.FC<TemplateHeaderProps> = ({
 		<>
 			<PageHeader
 				title={title}
-				subtitle={t("template.subtitle")}
 				actions={
 					<PrimaryButton icon={<AddIcon />} onClick={onCreate}>
 						{t("template.create")}

--- a/src/components/transfer/Table/transfersTableConfigs.tsx
+++ b/src/components/transfer/Table/transfersTableConfigs.tsx
@@ -6,7 +6,6 @@ import { designTokens, numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatQuantity } from "utils/formatCurrency";
 
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import WarehouseOutlinedIcon from "@mui/icons-material/WarehouseOutlined";
 import { Box, Typography } from "@mui/material";
 
@@ -108,15 +107,6 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 				<Typography component="span" sx={{ color: "text.secondary", whiteSpace: "nowrap" }}>
 					{transfer.createdBy}
 				</Typography>
-			),
-		},
-		{
-			key: "chevron",
-			headerName: "",
-			width: 48,
-			align: "right",
-			renderCell: () => (
-				<ChevronRightIcon sx={{ fontSize: 17, color: "text.disabled", display: "block" }} />
 			),
 		},
 	];

--- a/src/components/warehouse/Detail/WarehouseKpis.tsx
+++ b/src/components/warehouse/Detail/WarehouseKpis.tsx
@@ -7,7 +7,6 @@ import { formatCurrency, formatQuantity } from "utils/formatCurrency";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import PaymentsOutlinedIcon from "@mui/icons-material/PaymentsOutlined";
-import PlaceOutlinedIcon from "@mui/icons-material/PlaceOutlined";
 import { Box, Paper, Typography } from "@mui/material";
 
 interface WarehouseKpisProps {
@@ -68,63 +67,39 @@ export const WarehouseKpis: React.FC<WarehouseKpisProps> = ({ warehouse }) => {
 	const { t } = useTranslation();
 
 	return (
-		<>
-			{warehouse.location && (
-				<Box
-					sx={{
-						display: "inline-flex",
-						alignItems: "center",
-						gap: "7px",
-						fontSize: 13.5,
-						color: "text.secondary",
-						...numericSx,
-						mb: "16px",
-					}}
-				>
-					<PlaceOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />
-					{warehouse.location}
-				</Box>
-			)}
-
-			<Box
-				sx={{
-					display: "grid",
-					gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
-					gap: "16px",
-					mb: "20px",
-				}}
-			>
-				<Kpi
-					icon={<Inventory2OutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
-					caption={t("warehouse.kpi.products")}
-					value={formatQuantity(warehouse.productCount)}
-					sub={t("warehouse.kpi.productsSub")}
-				/>
-				<Kpi
-					icon={<LayersOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
-					caption={t("warehouse.kpi.units")}
-					value={
-						<>
-							{formatQuantity(warehouse.totalUnits)}
-							<Unit>{t("warehouse.kpi.unitsSuffix")}</Unit>
-						</>
-					}
-					sub={t("warehouse.kpi.unitsSub")}
-				/>
-				<Kpi
-					accent
-					icon={<PaymentsOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
-					caption={t("warehouse.kpi.value")}
-					value={
-						<>
-							{formatCurrency(warehouse.stockValue)}
-							<Unit>UZS</Unit>
-						</>
-					}
-					sub={t("warehouse.kpi.valueSub")}
-				/>
-			</Box>
-		</>
+		<Box
+			sx={{
+				display: "grid",
+				gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+				gap: "16px",
+				mb: "20px",
+			}}
+		>
+			<Kpi
+				icon={<Inventory2OutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
+				caption={t("warehouse.kpi.products")}
+				value={formatQuantity(warehouse.productCount)}
+				sub={t("warehouse.kpi.productsSub")}
+			/>
+			<Kpi
+				icon={<LayersOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
+				caption={t("warehouse.kpi.units")}
+				value={formatQuantity(warehouse.totalUnits)}
+				sub={t("warehouse.kpi.unitsSub")}
+			/>
+			<Kpi
+				accent
+				icon={<PaymentsOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />}
+				caption={t("warehouse.kpi.value")}
+				value={
+					<>
+						{formatCurrency(warehouse.stockValue)}
+						<Unit>UZS</Unit>
+					</>
+				}
+				sub={t("warehouse.kpi.valueSub")}
+			/>
+		</Box>
 	);
 };
 

--- a/src/components/warehouse/Form/WarehouseFormModal.tsx
+++ b/src/components/warehouse/Form/WarehouseFormModal.tsx
@@ -102,6 +102,8 @@ const WarehouseFormModal: React.FC<WarehouseFormModalProps> = ({
 										value={field.value ?? ""}
 										size="small"
 										fullWidth
+										multiline
+										minRows={2}
 										placeholder={t("warehouse.form.addressPlaceholder")}
 										disabled={isSaving}
 										error={!!fieldState.error}

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -150,6 +150,19 @@
   "common.download.png": "Скачать PNG",
   "common.download.print": "Печать",
 
+  "common.month.1": "Январь",
+  "common.month.2": "Февраль",
+  "common.month.3": "Март",
+  "common.month.4": "Апрель",
+  "common.month.5": "Май",
+  "common.month.6": "Июнь",
+  "common.month.7": "Июль",
+  "common.month.8": "Август",
+  "common.month.9": "Сентябрь",
+  "common.month.10": "Октябрь",
+  "common.month.11": "Ноябрь",
+  "common.month.12": "Декабрь",
+
   "currency.UZS": "UZS (сўм)",
   "currency.USD": "USD ($)",
   "currency.RUB": "RUB (₽)"

--- a/src/pages/EmployeeDetailPage.tsx
+++ b/src/pages/EmployeeDetailPage.tsx
@@ -13,6 +13,7 @@ import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
 import WalletLink from "components/wallet/Links/WalletLink";
 import { EmployeeFormPayload } from "hooks/employee/useEmployeeForm";
 import { PayrollFormPayload } from "hooks/payroll/usePayrollForm";
+import { TFunction } from "i18next";
 import { observer } from "mobx-react-lite";
 import { PaymentRecord } from "models/payment";
 import { PATHS } from "routing/paths";
@@ -27,23 +28,13 @@ import PersonOffOutlinedIcon from "@mui/icons-material/PersonOffOutlined";
 import RestartAltOutlinedIcon from "@mui/icons-material/RestartAltOutlined";
 import { Box, CircularProgress, Paper, Typography } from "@mui/material";
 
-const MONTHS_RU = [
-	"Январь",
-	"Февраль",
-	"Март",
-	"Апрель",
-	"Май",
-	"Июнь",
-	"Июль",
-	"Август",
-	"Сентябрь",
-	"Октябрь",
-	"Ноябрь",
-	"Декабрь",
-];
-const periodLabel = (iso: string): string => {
-	const d = new Date(iso);
-	return `${MONTHS_RU[d.getMonth()]} ${d.getFullYear()}`;
+/** «Июль 2026» from a payroll period ("YYYY-MM") or an ISO date, via i18n month names. */
+const monthYearLabel = (t: TFunction, value: string): string => {
+	const match = /^(\d{4})-(\d{2})/.exec(value);
+	if (!match) {
+		return value;
+	}
+	return `${t(`common.month.${Number(match[2])}`)} ${match[1]}`;
 };
 
 const Stat: React.FC<{ label: string; value: React.ReactNode; accent?: boolean }> = ({
@@ -157,10 +148,10 @@ const EmployeeDetailPage: React.FC = observer(() => {
 			{
 				key: "period",
 				headerName: t("employee.payroll.period"),
-				sortValue: (p) => p.period ?? periodLabel(p.date),
+				sortValue: (p) => p.period ?? p.date,
 				renderCell: (p) => (
 					<Box component="span" sx={{ color: "text.secondary" }}>
-						{p.period ?? periodLabel(p.date)}
+						{monthYearLabel(t, p.period ?? p.date)}
 					</Box>
 				),
 			},
@@ -334,7 +325,9 @@ const EmployeeDetailPage: React.FC = observer(() => {
 				/>
 				<Stat
 					accent
-					label={t("employee.stat.paidThisMonth", { month: MONTHS_RU[now.getMonth()] })}
+					label={t("employee.stat.paidThisMonth", {
+						month: t(`common.month.${now.getMonth() + 1}`),
+					})}
 					value={
 						<>
 							{formatCurrency(paidThisMonth)}{" "}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -145,7 +145,11 @@ const ProductDetailPage: React.FC = observer(() => {
 			label: t("product.detail.tabs.transactions"),
 			count: transactions === "loading" ? undefined : transactions.length,
 		},
-		{ key: "movements", label: t("product.detail.tabs.movements") },
+		{
+			key: "movements",
+			label: t("product.detail.tabs.movements"),
+			count: movements === "loading" ? undefined : movements.length,
+		},
 	];
 
 	return (

--- a/src/pages/WarehouseDetailPage.tsx
+++ b/src/pages/WarehouseDetailPage.tsx
@@ -20,6 +20,7 @@ import { OpeningStockFormValues, WarehouseFormValues } from "schemas/WarehouseSc
 import { useStore } from "stores/StoreContext";
 
 import AddIcon from "@mui/icons-material/Add";
+import PlaceOutlinedIcon from "@mui/icons-material/PlaceOutlined";
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 
 type WarehouseDetailTab = "stock" | "movements";
@@ -133,6 +134,14 @@ const WarehouseDetailPage: React.FC = observer(() => {
 			<DetailPageHeader
 				backTo={PATHS.warehouses}
 				title={warehouse.name}
+				meta={
+					warehouse.location ? (
+						<>
+							<PlaceOutlinedIcon sx={{ fontSize: 16, color: "text.disabled" }} />
+							{warehouse.location}
+						</>
+					) : undefined
+				}
 				actions={actions}
 				primaryAction={primaryAction}
 				isArchived={warehouse.isArchived}


### PR DESCRIPTION
Fourth branch, **stacked on `redesign/issue-form-conventions`** (PR #76 → #75 → #74). First pass over the §6 module backlog.

- **Products modal** — the Category field is now marked required («Категория*»); the schema already required it, so this fixes a label/UI inconsistency. *(Verified live: star present in the create modal.)*
- **Product detail** — the «Движения» tab gets a count pill (it was the only tab lacking one).
- **Transfers list** — removed the decorative right-chevron column; the row already opens the read-only detail on click.
- **Templates** — removed the page subheader.

**Refund badge (§6 item 10):** confirmed the «Возврат» / «Возврат поставки» marker (undo icon + label) **already exists** in `TransactionTypeBadge`, which the sales/supplies list uses — so the decided "keep hue + add marker" is already satisfied. No change made.

## Still open in §6 (follow-up)
Products preselect-first-category (needs category-store + open-timing wiring), product-detail prices redesign, warehouses (address multiline / drop «ед.» / address-beside-title), adjustments summary-on-select, transfers POS-style stock dropdown, partner ledger Description column, orders merge widgets + №wrap, sales/supplies sum-widget, templates expanded-lines restyle, wallets header simplify + transfer-modal row, employees payroll period i18n.

## Verification
`npm run validate` clean. Live: product create modal shows «Категория*»; other items are trivial (a count expression + two removals), build-verified.