### PR TITLE
Filters: add the two missing searches — transfers list + wallet transfers tab (XC-3)

### DIFF
--- a/src/components/transfer/Header/TransferHeader.tsx
+++ b/src/components/transfer/Header/TransferHeader.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import GhostButton from "components/shared/Buttons/GhostButton";
 import PageHeader from "components/shared/PageHeader/PageHeader";
 import { PrimaryButton } from "components/shared/PrimaryButton/PrimaryButton";
+import { SearchInput } from "components/shared/SearchInput/SearchInput";
 import { Warehouse } from "models/warehouse";
 import { designTokens } from "theme";
 
@@ -16,6 +17,8 @@ interface TransferHeaderProps {
 	warehouses: Warehouse[];
 	warehouseFilter: number | null;
 	onWarehouseChange: (warehouseId: number | null) => void;
+	search: string;
+	onSearchChange: (value: string) => void;
 	onCreate: () => void;
 	onExport: () => void;
 }
@@ -32,6 +35,8 @@ const TransferHeader: React.FC<TransferHeaderProps> = ({
 	warehouses,
 	warehouseFilter,
 	onWarehouseChange,
+	search,
+	onSearchChange,
 	onCreate,
 	onExport,
 }) => {
@@ -59,6 +64,12 @@ const TransferHeader: React.FC<TransferHeaderProps> = ({
 			/>
 
 			<Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2, flexWrap: "wrap" }}>
+				<SearchInput
+					value={search}
+					onChange={onSearchChange}
+					placeholder={t("transfer.searchPlaceholder")}
+					sx={{ width: { xs: "100%", sm: 300 } }}
+				/>
 				<TextField
 					select
 					size="small"

--- a/src/components/wallet/Detail/WalletTransfersTab.tsx
+++ b/src/components/wallet/Detail/WalletTransfersTab.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import GhostButton from "components/shared/Buttons/GhostButton";
+import { SearchInput } from "components/shared/SearchInput/SearchInput";
 import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
 import WalletLink from "components/wallet/Links/WalletLink";
 import { WalletTypeAvatar } from "components/wallet/WalletPresentation";
@@ -8,6 +9,7 @@ import { WalletTransfer } from "models/wallet";
 import { numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
+import { matchesSearch } from "utils/stringUtils";
 
 import AddIcon from "@mui/icons-material/Add";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
@@ -49,6 +51,7 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 	onOpenTransfer,
 }) => {
 	const { t } = useTranslation();
+	const [query, setQuery] = useState("");
 
 	const columns = useMemo<Column<WalletTransfer>[]>(
 		() => [
@@ -106,6 +109,16 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 		[t],
 	);
 
+	const filtered = useMemo(
+		() =>
+			query.trim()
+				? transfers.filter((tr) =>
+						matchesSearch([tr.fromWalletName, tr.toWalletName, tr.createdBy].join(" "), query),
+					)
+				: transfers,
+		[transfers, query],
+	);
+
 	if (transfers.length === 0) {
 		return (
 			<Paper
@@ -135,13 +148,23 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 	}
 
 	return (
-		<DataTable<WalletTransfer>
-			rows={transfers}
-			columns={columns}
-			pagination
-			defaultSort={{ key: "date", order: "desc" }}
-			onRowClick={(tr) => onOpenTransfer(tr.id)}
-		/>
+		<Box>
+			<Box sx={{ mb: "12px" }}>
+				<SearchInput
+					value={query}
+					onChange={setQuery}
+					placeholder={t("wallet.transfers.searchPlaceholder")}
+					sx={{ width: { xs: "100%", sm: 300 } }}
+				/>
+			</Box>
+			<DataTable<WalletTransfer>
+				rows={filtered}
+				columns={columns}
+				pagination
+				defaultSort={{ key: "date", order: "desc" }}
+				onRowClick={(tr) => onOpenTransfer(tr.id)}
+			/>
+		</Box>
 	);
 };
 

--- a/src/i18n/ru/transfer.json
+++ b/src/i18n/ru/transfer.json
@@ -5,6 +5,7 @@
   "transfer.success.create": "Перемещение проведено: {{from}} → {{to}}, {{positions}} поз.",
 
   "transfer.title": "Перемещения",
+  "transfer.searchPlaceholder": "Поиск по складу или автору…",
   "transfer.create": "Новое перемещение",
   "transfer.unitFallback": "ед.",
 

--- a/src/i18n/ru/wallet.json
+++ b/src/i18n/ru/wallet.json
@@ -108,6 +108,7 @@
   "wallet.transfers.to": "В кассу",
   "wallet.transfers.amount": "Сумма",
   "wallet.transfers.createdBy": "Создал",
+  "wallet.transfers.searchPlaceholder": "Поиск по кассе или автору…",
   "wallet.transfers.emptyTitle": "Нет переводов",
   "wallet.transfers.emptyBody": "Между этой и другими кассами ещё не было переводов.",
 

--- a/src/pages/TransferPage.tsx
+++ b/src/pages/TransferPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import TransferDetailModal from "components/transfer/Detail/TransferDetailModal";
 import TransferFormModal from "components/transfer/Form/TransferFormModal";
@@ -11,12 +11,14 @@ import { TransferFormValues } from "schemas/TransferSchema";
 import { useStore } from "stores/StoreContext";
 import { formatDate } from "utils/dateUtils";
 import { CsvColumn, csvDateStamp, exportToCsv } from "utils/exportToCsv";
+import { matchesSearch } from "utils/stringUtils";
 
 import { Box } from "@mui/material";
 
 const TransferPage: React.FC = observer(() => {
 	const { t } = useTranslation();
 	const { transferStore, warehouseStore, productStore } = useStore();
+	const [search, setSearch] = useState("");
 
 	useEffect(() => {
 		warehouseStore.getAll();
@@ -58,8 +60,16 @@ const TransferPage: React.FC = observer(() => {
 	const all = transferStore.allTransfers === "loading" ? null : transferStore.allTransfers;
 	const totalCount = all?.length ?? null;
 	const hasAny = (all?.length ?? 0) > 0;
-	const isFiltering = transferStore.warehouseFilter != null;
+	const isFiltering = transferStore.warehouseFilter != null || search.trim() !== "";
 	const dialogMode = transferStore.dialogMode;
+
+	const base = transferStore.filteredTransfers;
+	const rows =
+		base === "loading" || search.trim() === ""
+			? base
+			: base.filter((tr) =>
+					matchesSearch([tr.fromWarehouseName, tr.toWarehouseName, tr.createdBy].join(" "), search),
+				);
 
 	return (
 		<Box>
@@ -68,12 +78,14 @@ const TransferPage: React.FC = observer(() => {
 				warehouses={activeWarehouses}
 				warehouseFilter={transferStore.warehouseFilter}
 				onWarehouseChange={transferStore.setWarehouseFilter}
+				search={search}
+				onSearchChange={setSearch}
 				onCreate={transferStore.openCreate}
 				onExport={handleExport}
 			/>
 
 			<TransfersTable
-				rows={transferStore.filteredTransfers}
+				rows={rows}
 				isFiltering={isFiltering}
 				hasAny={hasAny}
 				onOpen={transferStore.openDetail}


### PR DESCRIPTION
Fifth branch, **stacked on `redesign/issue-module-polish`** (#77 → #76 → #75 → #74). Completes the XC-3 "add missing searches" item.

- **Transfers list** — `SearchInput` added to `TransferHeader`, wired through `TransferPage`; filters the (warehouse-filtered) set by from/to warehouse name + author via `matchesSearch`. The empty-state now also covers "no matches".
- **Wallet «Переводы» tab** — `SearchInput` above the `DataTable`, filtering by from/to wallet name + author, mirroring the «Операции» tab which already had search.

## Verification
`npm run validate` clean. Live on :3000: the transfers list shows «Поиск по складу или автору…» and a non-matching query filters the list to an empty state.

## Not in this PR (Branch 4 remainder)
XC-1 (typeahead filters: stocks category, adjustments/movements warehouse, payments wallet), XC-15 (filters inside the table widget), and XC-14 (offline UX — stop firing when offline + single header indicator, DEC-11) are larger/independent and not included here.