### PR TITLE
Module polish (round 2): preselect first category, remove wallet transfer preview, payments partner-type + F18

### DIFF
--- a/docs/frontend-gaps.md
+++ b/docs/frontend-gaps.md
@@ -231,4 +231,6 @@ One line per module — what it does today + notable absences. No judgments.
 
 ---
 
-*End of regenerated list. Items A1–A26, F1–F17, U1–U3 above are the verified state as of 2026-07-09 against `openapi.json` (2026-07-05) and the current `redesign/bug-fixes` working tree.*
+**F18 — Payment detail omits notes + attachments (Important; found 2026-07-15).** `CreatePaymentRequest` accepts `notes?: string` and `attachments?: File[]` (`models/payment.ts:60,69`; openapi payment-create carries `Notes`/`Attachments`), but the served detail `PaymentRecord` (`models/payment.ts:138-174`) returns **neither** — only a General-only `description`. So a note or attachment entered at creation is silently dropped from the detail view. The §6 "add notes + attachments sections to Payments detail" item is **FE-blocked** until the payment GET serves `notes` + attachment metadata (`{id, name, url}`); FE keeps no stub.
+
+*End of regenerated list. Items A1–A26, F1–F18, U1–U3 above are the verified state as of 2026-07-09 against `openapi.json` (2026-07-05) and the current `redesign/bug-fixes` working tree.*

--- a/src/components/payment/Detail/PaymentDetailCards.tsx
+++ b/src/components/payment/Detail/PaymentDetailCards.tsx
@@ -376,7 +376,6 @@ export const PaymentInfoCard: React.FC<{
 							>
 								{payment.partnerName}
 							</Box>
-							{payment.partnerType && ` · ${t(`payment.partnerType.${payment.partnerType}`)}`}
 						</>,
 					)}
 				{payment.employeeName &&

--- a/src/components/product/Form/ProductFormModal.tsx
+++ b/src/components/product/Form/ProductFormModal.tsx
@@ -54,17 +54,25 @@ const ProductFormModal: React.FC<ProductFormModalProps> = ({
 	}, [isOpen, categoryStore]);
 
 	const categories = categoryStore.allCategories === "loading" ? [] : categoryStore.allCategories;
-	const singleCategoryId = categories.length === 1 ? categories[0].id : null;
+	const firstCategoryId =
+		categories.length > 0
+			? [...categories].sort((a, b) => a.name.localeCompare(b.name, "ru"))[0].id
+			: null;
 
-	// Pre-select the category only when the tenant has exactly one (no
-	// default-category concept — canon rule 42). Create flow only; not marked
-	// dirty so closing an untouched form doesn't prompt.
+	// Pre-select the first category (A–Z) on create — there is no default-category
+	// concept (canon rule 42), so the alphabetically-first is the sensible default.
+	// Create flow only; not marked dirty so closing an untouched form doesn't prompt.
 	useEffect(() => {
-		if (isOpen && !product && singleCategoryId != null) {
-			form.form.setValue("categoryId", singleCategoryId, { shouldDirty: false });
+		if (
+			isOpen &&
+			!product &&
+			firstCategoryId != null &&
+			form.form.getValues("categoryId") == null
+		) {
+			form.form.setValue("categoryId", firstCategoryId, { shouldDirty: false });
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isOpen, product, singleCategoryId]);
+	}, [isOpen, product, firstCategoryId]);
 
 	const handleGenerateSku = () =>
 		form.form.setValue("sku", generateSku(), { shouldDirty: true, shouldValidate: true });

--- a/src/components/wallet/Form/WalletTransferModal.tsx
+++ b/src/components/wallet/Form/WalletTransferModal.tsx
@@ -100,35 +100,6 @@ const WalletPicker: React.FC<{
 	</Select>
 );
 
-/** Compact route node for the live preview (from / to). */
-const RouteNode: React.FC<{ label: string; wallet: Wallet | null }> = ({ label, wallet }) => (
-	<Box sx={{ display: "flex", alignItems: "center", gap: "9px", minWidth: 0 }}>
-		{wallet ? (
-			<WalletTypeAvatar type={wallet.type} size={30} iconSize={16} />
-		) : (
-			<Box
-				sx={{
-					width: 30,
-					height: 30,
-					borderRadius: "8px",
-					display: "grid",
-					placeItems: "center",
-					bgcolor: designTokens.gray100,
-					color: designTokens.gray400,
-				}}
-			>
-				<AccountBalanceWalletOutlinedIcon sx={{ fontSize: 16 }} />
-			</Box>
-		)}
-		<Box sx={{ minWidth: 0 }}>
-			<Typography sx={{ fontSize: 11, color: "text.disabled" }}>{label}</Typography>
-			<Typography sx={{ fontSize: 13.5, fontWeight: 600, whiteSpace: "nowrap" }}>
-				{wallet?.name ?? "—"}
-			</Typography>
-		</Box>
-	</Box>
-);
-
 const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 	isOpen,
 	isSaving,
@@ -154,7 +125,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 	const amount = watch("amount");
 
 	const fromWallet = wallets.find((w) => w.id === fromId) ?? null;
-	const toWallet = wallets.find((w) => w.id === toId) ?? null;
 	const available = fromWallet?.balance ?? 0;
 	const over = !!fromWallet && amount > available;
 
@@ -194,41 +164,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 				{isSaving && <LinearProgress />}
 
 				<DialogContent dividers sx={{ pt: 2 }}>
-					{/* live route preview */}
-					<Box
-						sx={{
-							display: "flex",
-							alignItems: "center",
-							gap: "12px",
-							p: "14px 16px",
-							mb: "18px",
-							bgcolor: designTokens.gray25,
-							border: "1px solid",
-							borderColor: "divider",
-							borderRadius: "12px",
-						}}
-					>
-						<RouteNode label={t("wallet.transfer.from")} wallet={fromWallet} />
-						<ChevronRightIcon sx={{ fontSize: 18, color: "primary.main", flex: "0 0 auto" }} />
-						<RouteNode label={t("wallet.transfer.to")} wallet={toWallet} />
-						<Typography
-							sx={{
-								ml: "auto",
-								...numericSx,
-								fontWeight: 800,
-								fontSize: 19,
-								letterSpacing: "-0.02em",
-								color: amount > 0 && !over ? "text.primary" : "text.disabled",
-								flex: "0 0 auto",
-							}}
-						>
-							{formatCurrency(amount > 0 ? amount : 0)}{" "}
-							<Box component="span" sx={{ fontSize: 12, fontWeight: 600, color: "text.disabled" }}>
-								UZS
-							</Box>
-						</Typography>
-					</Box>
-
 					<Stack sx={{ gap: "16px" }}>
 						{/* Source → destination on one row (WAL-17). */}
 						<Box


### PR DESCRIPTION
Sixth branch, **stacked on `redesign/issue-filters`** (#78→#77→#76→#75→#74). Second §6 pass — the decided items.

- **Products modal** — preselect the **first category (A–Z)** on create (was: only when the tenant had exactly one). No default-category concept (rule 42), so alphabetically-first is the sensible default; edit keeps the served category. *(Verified live: opens preset to «Автомобильное».)*
- **Wallet transfer modal** — removed the redundant live from→to→amount preview row (it duplicated the pickers + amount below); dropped the now-unused `RouteNode` component and `toWallet`.
- **Payment detail** — dropped the « · Клиент/Поставщик» partner-type suffix from the partner row.
- **`docs/frontend-gaps.md` F18** — recorded that the served `PaymentRecord` detail omits `notes` + attachment metadata (only General `description`), though the create request accepts them. The §6 "notes + attachments sections" item is **FE-blocked** until the payment GET serves those fields — **no stub added** (per the contract-discipline rule).

## Verification
`npm run validate` clean (0 errors). Live: product create modal category preselected; wallet transfer modal no longer shows the preview row.