### PR TITLE
Typography (XC-17, pass 1): visible detail-table separators + heavier SKU cell

### DIFF
--- a/src/components/product/Table/productsTableConfigs.tsx
+++ b/src/components/product/Table/productsTableConfigs.tsx
@@ -104,6 +104,7 @@ export function buildProductColumns({
 					sx={{
 						...numericSx,
 						fontSize: 12.5,
+						fontWeight: 500,
 						color: "text.secondary",
 						...archivedCellSx(product),
 					}}

--- a/src/components/shared/Detail/detailTableChrome.ts
+++ b/src/components/shared/Detail/detailTableChrome.ts
@@ -40,7 +40,9 @@ export const detailBodyCellSx = {
 	height: 48,
 	p: "12px 18px",
 	borderBottom: "1px solid",
-	borderColor: designTokens.gray25,
+	// gray100 (was near-white gray25) so row separators are actually visible while
+	// staying subtler than the divider-coloured header underline (XC-17).
+	borderColor: designTokens.gray100,
 	fontSize: 13.5,
 	verticalAlign: "middle",
 } as const;


### PR DESCRIPTION
Seventh branch, **stacked on `redesign/issue-polish-2`**. First XC-17 typography pass — you asked me to choose and apply; here are two grounded, central changes to review.

- **Detail-table row separators** — `detailTableChrome.detailBodyCellSx` border moves from the near-white `gray25` to `gray100`, so row separators in the detail-embedded tables are actually visible (still subtler than the `divider`-coloured header underline). One central change → Product / Warehouse / Transfer detail tables + Partner ledger/transactions/payments tabs. *(Verified live: computed `rgb(236,232,223)`.)*
- **Products list SKU cell** — `fontWeight: 500` (was default 400) so the identifier reads less thin.

## Remaining XC-17 (follow-up, for your review)
Transfer "lines vs quantity" weight mismatch, image-name weight, per-cell date/author styling — these are finer per-surface calls; happy to do a second pass once you've eyeballed these two.

## Verification
`npm run validate` clean; separator change confirmed live on the partner ledger.