### PR TITLE
Module polish (round 3): orders merge, ledger Номер column, sales sum-widget, initial-stock

### DIFF
--- a/src/components/order/Detail/OrderSidebar.tsx
+++ b/src/components/order/Detail/OrderSidebar.tsx
@@ -2,19 +2,18 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import OrderSourceChip from "components/order/OrderSourceChip";
 import OrderStatusChip from "components/order/OrderStatusChip";
-import PartnerAvatar from "components/partner/PartnerAvatar";
 import DetailCard from "components/shared/Detail/DetailCard";
 import { Order } from "models/order";
 import { designTokens, numericSx } from "theme";
 import { formatCurrency } from "utils/formatCurrency";
-import { isOrderEditable, ORDER_NEXT_STEP, orderTotal } from "utils/orderUtils";
+import { isOrderEditable, ORDER_NEXT_STEP, orderSubtotal, orderTotal } from "utils/orderUtils";
 
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
 import { Box, Typography } from "@mui/material";
 
 const FinRow: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-	<Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+	<Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "12px" }}>
 		<Box component="span" sx={{ fontSize: 13.5, color: "text.secondary" }}>
 			{label}
 		</Box>
@@ -22,12 +21,18 @@ const FinRow: React.FC<{ label: string; children: React.ReactNode }> = ({ label,
 	</Box>
 );
 
+/**
+ * Order summary rail — a single card (merged from the former partner + financial
+ * cards): the order amount hero, then Партнёр / Скидка / Статус / Источник rows,
+ * and the customer balance. The line count is intentionally dropped.
+ */
 export const OrderSidebar: React.FC<{ order: Order; onOpenCustomer: () => void }> = ({
 	order,
 	onOpenCustomer,
 }) => {
 	const { t } = useTranslation();
 	const total = orderTotal(order.lines);
+	const discount = orderSubtotal(order.lines) - total;
 	const step = ORDER_NEXT_STEP[order.status];
 
 	const balance = order.customerBalance;
@@ -41,66 +46,6 @@ export const OrderSidebar: React.FC<{ order: Order; onOpenCustomer: () => void }
 
 	return (
 		<>
-			{/* partner mini */}
-			<DetailCard>
-				<Box sx={{ p: "16px 18px" }}>
-					<Box sx={{ display: "flex", alignItems: "center", gap: "12px" }}>
-						<PartnerAvatar name={order.customerName} size={44} />
-						<Box sx={{ minWidth: 0 }}>
-							<Typography
-								onClick={onOpenCustomer}
-								sx={{
-									fontSize: 15,
-									fontWeight: 700,
-									color: "primary.main",
-									cursor: "pointer",
-									"&:hover": { textDecoration: "underline" },
-								}}
-							>
-								{order.customerName}
-							</Typography>
-							<Box
-								component="span"
-								sx={{
-									display: "inline-flex",
-									mt: "4px",
-									px: "8px",
-									py: "1px",
-									borderRadius: "999px",
-									fontSize: 11,
-									fontWeight: 600,
-									color: "info.main",
-									bgcolor: designTokens.infoBg,
-									border: "1px solid",
-									borderColor: designTokens.infoBorder,
-								}}
-							>
-								{t(`order.partnerType.${order.customerType}`)}
-							</Box>
-						</Box>
-					</Box>
-					<Box
-						sx={{
-							mt: "14px",
-							pt: "13px",
-							borderTop: "1px solid",
-							borderColor: "divider",
-							display: "flex",
-							justifyContent: "space-between",
-							alignItems: "center",
-						}}
-					>
-						<Typography sx={{ fontSize: 12.5, color: "text.secondary" }}>
-							{t("order.detail.customerBalance")}
-						</Typography>
-						<Typography sx={{ ...numericSx, fontSize: 13.5, fontWeight: 700, color: balanceColor }}>
-							{balanceLabel}
-						</Typography>
-					</Box>
-				</Box>
-			</DetailCard>
-
-			{/* financial */}
 			<DetailCard>
 				<Box sx={{ p: "18px" }}>
 					<Typography sx={{ fontSize: 12.5, color: "text.secondary" }}>
@@ -125,6 +70,7 @@ export const OrderSidebar: React.FC<{ order: Order; onOpenCustomer: () => void }
 							UZS
 						</Box>
 					</Typography>
+
 					<Box
 						sx={{
 							mt: "18px",
@@ -136,18 +82,54 @@ export const OrderSidebar: React.FC<{ order: Order; onOpenCustomer: () => void }
 							gap: "13px",
 						}}
 					>
-						<FinRow label={t("order.detail.positionsCount")}>
-							<Box component="span" sx={{ ...numericSx, fontWeight: 600 }}>
-								{order.lines.length}
+						<FinRow label={t("order.detail.customer")}>
+							<Box
+								component="span"
+								onClick={onOpenCustomer}
+								sx={{
+									fontWeight: 700,
+									color: "primary.main",
+									cursor: "pointer",
+									textAlign: "right",
+									"&:hover": { textDecoration: "underline" },
+								}}
+							>
+								{order.customerName}
 							</Box>
 						</FinRow>
-						<FinRow label={t("order.col.source")}>
-							<OrderSourceChip source={order.source} />
+						<FinRow label={t("order.detail.discount")}>
+							<Box component="span" sx={{ ...numericSx, fontWeight: 600 }}>
+								{formatCurrency(discount)}
+							</Box>
 						</FinRow>
 						<FinRow label={t("order.col.status")}>
 							<OrderStatusChip status={order.status} />
 						</FinRow>
+						<FinRow label={t("order.col.source")}>
+							<OrderSourceChip source={order.source} />
+						</FinRow>
 					</Box>
+
+					<Box
+						sx={{
+							mt: "16px",
+							pt: "14px",
+							borderTop: "1px solid",
+							borderColor: "divider",
+							display: "flex",
+							justifyContent: "space-between",
+							alignItems: "center",
+							gap: "12px",
+						}}
+					>
+						<Typography sx={{ fontSize: 12.5, color: "text.secondary" }}>
+							{t("order.detail.customerBalance")}
+						</Typography>
+						<Typography sx={{ ...numericSx, fontSize: 15, fontWeight: 700, color: balanceColor }}>
+							{balanceLabel}
+						</Typography>
+					</Box>
+
 					{isOrderEditable(order.status) && (
 						<Box
 							sx={{

--- a/src/components/partner/Detail/LedgerTab.tsx
+++ b/src/components/partner/Detail/LedgerTab.tsx
@@ -26,7 +26,7 @@ import {
 import { EventCell, eventLabelKey } from "./ledgerMeta";
 
 type EventFilter = "all" | "sale" | "supply" | "payment" | "refund" | "opening";
-type SortCol = "date" | "event" | "amount" | "balance";
+type SortCol = "number" | "date" | "event" | "amount" | "balance";
 
 interface LedgerTabProps {
 	ledger: PartnerLedgerEntry[];
@@ -77,6 +77,8 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 	const sorted = useMemo(() => {
 		const accessor = (e: PartnerLedgerEntry): string | number => {
 			switch (sortCol) {
+				case "number":
+					return e.reference ?? "";
 				case "date":
 					return e.date;
 				case "event":
@@ -107,31 +109,13 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 		}
 	};
 
-	const description = (e: PartnerLedgerEntry): React.ReactNode => {
-		if (e.type === "opening") {
-			return (
-				<Box component="span" sx={{ color: "text.secondary" }}>
-					{t("partner.ledger.openingDesc")}
-				</Box>
-			);
-		}
-		return (
-			<Box component="span" sx={{ fontSize: 12.5, color: "text.secondary" }}>
-				<Box component="span" sx={{ color: "primary.main", fontWeight: 500 }}>
-					{e.reference}
-				</Box>
-				{e.itemCount ? ` · ${t("partner.ledger.items", { count: e.itemCount })}` : ""}
-			</Box>
-		);
-	};
-
 	const handleExport = () => {
 		exportToCsv<PartnerLedgerEntry>(
 			`partner_${partnerName}_ledger_${csvDateStamp()}`,
 			[
 				{ header: t("partner.ledger.col.date"), value: (e) => formatDate(e.date) },
 				{ header: t("partner.ledger.col.event"), value: (e) => t(eventLabelKey(e.type)) },
-				{ header: t("partner.ledger.col.description"), value: descriptionText },
+				{ header: t("partner.ledger.col.number"), value: (e) => e.reference ?? "" },
 				{ header: t("partner.ledger.col.amount"), value: (e) => e.delta },
 				{ header: t("partner.ledger.col.balanceAfter"), value: (e) => e.balance },
 			],
@@ -224,6 +208,14 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 					<thead>
 						<tr>
 							<DetailSortHeader
+								col="number"
+								label={t("partner.ledger.col.number")}
+								active={sortCol === "number"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
 								col="date"
 								label={t("partner.ledger.col.date")}
 								active={sortCol === "date"}
@@ -239,9 +231,6 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 								onSort={onSort}
 								sx={headCellSx}
 							/>
-							<Box component="th" sx={headCellSx}>
-								{t("partner.ledger.col.description")}
-							</Box>
 							<DetailSortHeader
 								col="amount"
 								label={t("partner.ledger.col.amount")}
@@ -279,13 +268,28 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 									}}
 								>
 									<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
+										{e.reference ? (
+											<Box
+												component="span"
+												sx={{
+													color: "primary.main",
+													fontWeight: 600,
+													"&:hover": { textDecoration: "underline" },
+												}}
+											>
+												{e.reference}
+											</Box>
+										) : (
+											<Box component="span" sx={{ color: "text.disabled" }}>
+												—
+											</Box>
+										)}
+									</Box>
+									<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
 										{e.type === "opening" ? formatDate(e.date) : formatDateTime(e.date)}
 									</Box>
 									<Box component="td" sx={bodyCellSx}>
 										<EventCell type={e.type} label={t(eventLabelKey(e.type))} />
-									</Box>
-									<Box component="td" sx={bodyCellSx}>
-										{description(e)}
 									</Box>
 									<Box
 										component="td"

--- a/src/components/transaction/Detail/cards.tsx
+++ b/src/components/transaction/Detail/cards.tsx
@@ -99,7 +99,7 @@ export const SdCard: React.FC<{
 
 export const PositionsCard: React.FC<{
 	lines: TransactionLine[];
-	footer: React.ReactNode;
+	footer?: React.ReactNode;
 	count: number;
 }> = ({ lines, footer, count }) => {
 	const { t } = useTranslation();
@@ -269,10 +269,12 @@ export const RefundFooter: React.FC<{ lines: TransactionLine[] }> = ({ lines }) 
 export const SaleFinancialCard: React.FC<{
 	direction: TransactionDirection;
 	total: number;
+	subtotal: number;
+	discount: number;
 	paid: number;
 	remaining: number;
 	status: TransactionStatus;
-}> = ({ direction, total, paid, remaining, status }) => {
+}> = ({ direction, total, subtotal, discount, paid, remaining, status }) => {
 	const { t } = useTranslation();
 	return (
 		<SdCard>
@@ -310,6 +312,32 @@ export const SaleFinancialCard: React.FC<{
 						gap: "13px",
 					}}
 				>
+					<Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+						<Box component="span" sx={{ fontSize: 13.5, color: "text.secondary" }}>
+							{t("transaction.detail.subtotal")}
+						</Box>
+						<Box component="span" sx={{ ...numericSx, fontWeight: 600 }}>
+							{formatCurrency(subtotal)} UZS
+						</Box>
+					</Box>
+					<Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+						<Box component="span" sx={{ fontSize: 13.5, color: "text.secondary" }}>
+							{t("transaction.detail.discountByLines")}
+						</Box>
+						{discount ? (
+							<Box
+								component="span"
+								sx={{ ...numericSx, fontWeight: 600, color: designTokens.saffron700 }}
+							>
+								−{formatCurrency(discount)} UZS
+							</Box>
+						) : (
+							<Box component="span" sx={{ color: "text.disabled" }}>
+								—
+							</Box>
+						)}
+					</Box>
+					<Box sx={{ height: "1px", bgcolor: "divider" }} />
 					<Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
 						<Box component="span" sx={{ fontSize: 13.5, color: "text.secondary" }}>
 							{t("transaction.detail.fin.paid")}

--- a/src/components/warehouse/Form/OpeningStockModal.tsx
+++ b/src/components/warehouse/Form/OpeningStockModal.tsx
@@ -433,12 +433,6 @@ const OpeningStockModal: React.FC<OpeningStockModalProps> = ({
 						flexWrap: "wrap",
 					}}
 				>
-					<Typography sx={{ ...numericSx, fontSize: 12.5, color: "text.secondary" }}>
-						{t("warehouse.opening.footerSummary", {
-							count: completeLines.length,
-							value: formatCurrency(batchValue),
-						})}
-					</Typography>
 					<Box sx={{ flexGrow: 1 }} />
 					<GhostButton onClick={requestClose} disabled={isSaving}>
 						{t("common.cancel")}

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -80,6 +80,8 @@
   "order.detail.created": "создан",
   "order.detail.customerBalance": "Баланс клиента",
   "order.detail.orderAmount": "Сумма заказа",
+  "order.detail.customer": "Клиент",
+  "order.detail.discount": "Скидка",
   "order.detail.positionsCount": "Позиций",
   "order.detail.untouchedHint": "Деньги и склад не затронуты, пока заказ не доставлен",
   "order.detail.promoteHint": "Подтверждение доставки спишет товар со склада и создаст окончательную продажу.",

--- a/src/i18n/ru/partner.json
+++ b/src/i18n/ru/partner.json
@@ -93,6 +93,7 @@
   "partner.ledger.period.30": "30 дней",
   "partner.ledger.legendPos": "партнёр должен нам",
   "partner.ledger.legendNeg": "мы должны партнёру",
+  "partner.ledger.col.number": "Номер",
   "partner.ledger.col.date": "Дата",
   "partner.ledger.col.event": "Событие",
   "partner.ledger.col.description": "Описание",

--- a/src/pages/TransactionDetailPage.tsx
+++ b/src/pages/TransactionDetailPage.tsx
@@ -12,13 +12,17 @@ import {
 	RefundHistoryCard,
 	RefundReferenceBanner,
 	SaleFinancialCard,
-	SaleFooter,
 } from "components/transaction/Detail/cards";
 import TransactionDetailHeader from "components/transaction/Detail/TransactionDetailHeader";
 import RefundModal from "components/transaction/Refund/RefundModal";
 import { observer } from "mobx-react-lite";
 import { useStore } from "stores/StoreContext";
-import { isRefundType, TransactionDirection } from "utils/transactionUtils";
+import {
+	isRefundType,
+	TransactionDirection,
+	txDiscountTotal,
+	txSubtotal,
+} from "utils/transactionUtils";
 
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 
@@ -98,7 +102,7 @@ const TransactionDetailPage: React.FC<TransactionDetailPageProps> = observer(({ 
 					<PositionsCard
 						lines={tx.lines}
 						count={tx.lines.length}
-						footer={refund ? <RefundFooter lines={tx.lines} /> : <SaleFooter lines={tx.lines} />}
+						footer={refund ? <RefundFooter lines={tx.lines} /> : undefined}
 					/>
 
 					{!refund && refundsOf.length > 0 && (
@@ -125,6 +129,8 @@ const TransactionDetailPage: React.FC<TransactionDetailPageProps> = observer(({ 
 						<SaleFinancialCard
 							direction={direction}
 							total={tx.totalDue}
+							subtotal={txSubtotal(tx.lines)}
+							discount={txDiscountTotal(tx.lines)}
 							paid={tx.totalPaid}
 							remaining={tx.remaining ?? Math.max(tx.totalDue - tx.totalPaid, 0)}
 							status={tx.status}


### PR DESCRIPTION
Eighth branch, **stacked on `redesign/issue-typography`**. The §6 items you decided on.

- **Partner ledger** — replaced the mixed «Описание» column with a leading **«Номер»** column: the entry's reference rendered as a link (payment «P-…» numbers show today; sales/supplies stay «—» until the backend serves persisted numbers). Sortable. *(Verified live: headers now Номер/Дата/Событие/Сумма/Баланс после; P-2268 etc. render.)*
- **Orders detail** — merged the partner + financial cards into **one** card: amount hero, then **Клиент → Скидка → Статус → Источник**, then the customer balance (bolder). Line/positions count dropped. *(Verified live.)*
- **Sales/Supplies detail** — moved **Подытог / Скидка** from the positions-table footer into the financial sum card (the hero already shows the total). *(Verified live.)*
- **Initial-stock modal** — removed the duplicate footer summary in the action bar.

## Decisions applied
- Payment **notes/attachments** → **deferred** (new feature; the endpoints don't serve files — see F18).
- Wallet **header two-column redesign** → **deferred** to a later design pass (current widgets kept).

## Verification
`npm run validate` clean. Each item driven live on :3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order details now show a consolidated summary with customer, discount, status, source, and balance information.
  * Transaction financial details now include subtotal and line-item discounts.
  * Partner ledger tables now include a sortable, exportable reference number column.

* **Improvements**
  * Simplified transaction and order detail layouts.
  * Opening stock dialogs now have a cleaner footer with focused actions.
  * Added Russian translations for new order and ledger labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->