### PR TITLE
fix(employee): pay-modal page hang after a successful payroll payment (REC-5)

### DIFF
--- a/src/pages/EmployeeDetailPage.tsx
+++ b/src/pages/EmployeeDetailPage.tsx
@@ -75,6 +75,9 @@ const EmployeeDetailPage: React.FC = observer(() => {
 
 	useEffect(() => {
 		if (Number.isFinite(employeeId)) {
+			// Clear any lingering subject so the page shows its loader (not stale data)
+			// until getById resolves for this id.
+			employeeStore.setSelectedEmployee(null);
 			employeeStore.getById(employeeId);
 		}
 		return () => employeeStore.setSelectedEmployee(null);

--- a/src/stores/EmployeeStore.ts
+++ b/src/stores/EmployeeStore.ts
@@ -260,6 +260,7 @@ export class EmployeeStore implements IEmployeeStore {
 	}
 
 	openCreate(): void {
+		this.selectedEmployee = null;
 		this.setDialog({ kind: "form" });
 	}
 
@@ -292,10 +293,15 @@ export class EmployeeStore implements IEmployeeStore {
 	}
 
 	private setDialog(mode: DialogMode) {
-		const employee = "employee" in mode ? (mode.employee ?? null) : null;
-
 		this.dialogMode = mode;
-		this.selectedEmployee = employee;
+
+		// A dialog that targets an employee focuses it; closing a dialog (or an
+		// employee-less «create» mode) must NOT clear the focused employee — on the
+		// detail page that employee is the page subject, and wiping it drops the page
+		// into a permanent loader. openCreate clears it explicitly for a blank form.
+		if ("employee" in mode && mode.employee) {
+			this.selectedEmployee = mode.employee;
+		}
 	}
 
 	private applySort(data: Loadable<Employee[]>): Loadable<Employee[]> {


### PR DESCRIPTION
`EmployeeStore.setDialog()` cleared `selectedEmployee` on every dialog change, so `closeDialog()` after a successful payroll payment nulled the detail page's subject and dropped it into a permanent `<CircularProgress/>` (payroll history also wiped). The same latent hang affected terminate/restore from the detail page.

**Fix (root cause):** only set `selectedEmployee` when a dialog targets one; `openCreate` clears it explicitly for a blank form. The detail page also resets the subject before `getById` so it shows its loader (not stale data) while (re)loading.

**Live-verified** on :3000: after a successful payment the modal closes, the page renders (no spinner), and payroll history refreshes (0→1 row).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale employee details from appearing while loading another employee.
  * Ensured the employee creation form always opens blank.
  * Preserved the selected employee when closing dialogs or switching to modes without an associated employee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->