### PR TITLE
feat(transfer): source-warehouse stock in the product picker dropdown

### DIFF
--- a/src/components/transfer/Form/TransferFormModal.tsx
+++ b/src/components/transfer/Form/TransferFormModal.tsx
@@ -40,6 +40,8 @@ import {
 	Typography,
 } from "@mui/material";
 
+import TransferProductOption from "./TransferProductOption";
+
 export interface TransferFormModalProps {
 	isOpen: boolean;
 	isSaving: boolean;
@@ -273,6 +275,20 @@ const TransferFormModal: React.FC<TransferFormModalProps> = ({
 													error={!!fieldState.error}
 													additionalFilter={(p, text) => p.sku.toLowerCase().includes(text)}
 													onChange={(p) => field.onChange(p?.id ?? 0)}
+													renderOption={(optionProps, option) => {
+														const { key, ...liProps } =
+															optionProps as React.HTMLAttributes<HTMLLIElement> & {
+																key?: React.Key;
+															};
+														return (
+															<Box component="li" key={option.id} {...liProps} sx={{ gap: "12px" }}>
+																<TransferProductOption
+																	product={option}
+																	stock={availFor(option.id)}
+																/>
+															</Box>
+														);
+													}}
 												/>
 											)}
 										/>

--- a/src/components/transfer/Form/TransferProductOption.tsx
+++ b/src/components/transfer/Form/TransferProductOption.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Product } from "models/product";
+import { numericSx } from "theme";
+import { formatQuantity } from "utils/formatCurrency";
+import { MEASUREMENT_SHORT } from "utils/productUtils";
+
+import { Box, Typography } from "@mui/material";
+
+/**
+ * A transfer product-picker dropdown row: name + SKU, with the available stock
+ * at the source warehouse on the right — color-coded out (red) / low (amber) /
+ * ok (green), mirroring the POS product search. `stock` is the source-warehouse
+ * quantity the modal already computes for the selected «Откуда» warehouse.
+ */
+const TransferProductOption: React.FC<{ product: Product; stock: number }> = ({
+	product,
+	stock,
+}) => {
+	const unit = MEASUREMENT_SHORT[product.measurement];
+	const color = stock === 0 ? "error.main" : stock < 15 ? "warning.main" : "success.main";
+
+	return (
+		<>
+			<Box sx={{ flex: 1, minWidth: 0 }}>
+				<Typography sx={{ fontSize: 14, fontWeight: 600 }} noWrap>
+					{product.name}
+				</Typography>
+				<Typography sx={{ ...numericSx, fontSize: 12, color: "text.disabled" }} noWrap>
+					{product.sku}
+				</Typography>
+			</Box>
+			<Typography sx={{ ...numericSx, fontSize: 12, fontWeight: 600, flex: "0 0 auto", color }}>
+				{formatQuantity(stock)} {unit}
+			</Typography>
+		</>
+	);
+};
+
+export default TransferProductOption;


### PR DESCRIPTION
The transfer product dropdown listed names only, so users couldn't see availability at the source («Откуда») warehouse without selecting each product.

Adds a POS-style `renderOption` (new `TransferProductOption` component) showing **name + SKU + available stock at the source warehouse**, color-coded out (red) / low (amber, <15) / ok (green). Reuses the modal's existing `availFor()`, so stock recomputes when the source warehouse changes. `EntityAutocomplete` already forwards a custom `renderOption` via `...rest`. Extracting the option row also trims `TransferFormModal` below its prior length.

**Live-verified** on :3000: dropdown rows show e.g. «Большой Бетонный Плащ · ББП-4-0773 · 98 ед» (green), «… · 3 кг» (amber), «Cola … · 0 ед» (red).