### PR TITLE
polish(detail): payment-allocations footer, wallet hint, transfer route spacing

### DIFF
--- a/src/components/payment/Detail/PaymentDetailCards.tsx
+++ b/src/components/payment/Detail/PaymentDetailCards.tsx
@@ -102,8 +102,6 @@ const ALLOC_META: Record<PaymentAllocationKind, { labelKey: string; color: strin
 export const PaymentAllocationCard: React.FC<{ payment: PaymentRecord }> = ({ payment }) => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
-	const settling = payment.allocations.filter((a) => a.allocationType !== "ChangeReturn");
-	const total = settling.reduce((s, a) => s + a.amount, 0);
 
 	return (
 		<DetailCard
@@ -213,25 +211,6 @@ export const PaymentAllocationCard: React.FC<{ payment: PaymentRecord }> = ({ pa
 						);
 					})}
 				</tbody>
-			</Box>
-			<Box
-				sx={{
-					display: "flex",
-					alignItems: "center",
-					justifyContent: "flex-end",
-					gap: "8px",
-					p: "13px 18px",
-					borderTop: "1px solid",
-					borderColor: "divider",
-					bgcolor: designTokens.gray25,
-				}}
-			>
-				<Typography sx={{ fontSize: 13, color: "text.secondary" }}>
-					{t("payment.detail.distributed")}
-				</Typography>
-				<Box component="span" sx={{ ...numericSx, fontWeight: 800, fontSize: 15 }}>
-					{formatCurrency(total)} UZS
-				</Box>
 			</Box>
 		</DetailCard>
 	);

--- a/src/components/transfer/Detail/TransferDetailModal.tsx
+++ b/src/components/transfer/Detail/TransferDetailModal.tsx
@@ -20,8 +20,12 @@ interface TransferDetailModalProps {
 	onClose: () => void;
 }
 
-const RouteNode: React.FC<{ label: string; name: string }> = ({ label, name }) => (
-	<Box sx={{ flex: 1, minWidth: 0 }}>
+const RouteNode: React.FC<{ label: string; name: string; align?: "left" | "right" }> = ({
+	label,
+	name,
+	align = "left",
+}) => (
+	<Box sx={{ flex: 1, minWidth: 0, textAlign: align }}>
 		<Typography sx={{ fontSize: 11.5, color: "text.secondary", mb: "4px" }}>{label}</Typography>
 		<Typography
 			component="div"
@@ -80,7 +84,11 @@ export const TransferDetailModal: React.FC<TransferDetailModalProps> = ({ transf
 						borderRadius: "8px",
 					}}
 				>
-					<RouteNode label={t("transfer.detail.from")} name={transfer.fromWarehouseName} />
+					<RouteNode
+						label={t("transfer.detail.from")}
+						name={transfer.fromWarehouseName}
+						align="right"
+					/>
 					<Box
 						sx={{
 							width: 38,

--- a/src/components/wallet/Form/WalletTransferModal.tsx
+++ b/src/components/wallet/Form/WalletTransferModal.tsx
@@ -315,6 +315,19 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 							/>
 						</Stack>
 					</Stack>
+					<Box
+						sx={{
+							display: "flex",
+							alignItems: "center",
+							gap: "7px",
+							mt: "18px",
+							fontSize: 12.5,
+							color: designTokens.saffron700,
+						}}
+					>
+						<InfoOutlinedIcon sx={{ fontSize: 15, color: "warning.main" }} />
+						{t("wallet.transfer.immutableHint")}
+					</Box>
 				</DialogContent>
 
 				<DialogActions
@@ -327,19 +340,6 @@ const WalletTransferModal: React.FC<WalletTransferModalProps> = ({
 						bgcolor: designTokens.gray25,
 					}}
 				>
-					<Box
-						sx={{
-							display: "flex",
-							alignItems: "center",
-							gap: "7px",
-							fontSize: 12.5,
-							color: designTokens.saffron700,
-						}}
-					>
-						<InfoOutlinedIcon sx={{ fontSize: 15, color: "warning.main" }} />
-						{t("wallet.transfer.immutableHint")}
-					</Box>
-					<Box sx={{ flexGrow: 1 }} />
 					<GhostButton onClick={requestClose} disabled={isSaving}>
 						{t("common.cancel")}
 					</GhostButton>


### PR DESCRIPTION
Three small detail-view cleanups (tracker §6 / XC leftovers):

- **Payment detail (C2):** drop the redundant «Распределено» allocations-footer total — the payment amount is already shown on the source/info card. Removes the now-unused `settling`/`total`.
- **Wallet transfer modal (C3):** pull the immutability hint out of the `DialogActions` button row (where it crowded «Отмена»/«Перевести») to a full-width line at the end of the content.
- **Transfer detail (C5):** right-align the source route node so the «→» sits symmetrically between the two warehouses.

**Live-verified** on :3000: allocations card renders its table with no footer total; wallet transfer footer has only the two buttons (hint moved into content); transfer route gap is now 12px / 12px (was 177px / 12px).