### PR TITLE
fix(payment): route payment + allocation numbers through formatEntityId (DR-21)

### DIFF
--- a/src/components/payment/Detail/PaymentDetailCards.tsx
+++ b/src/components/payment/Detail/PaymentDetailCards.tsx
@@ -10,6 +10,7 @@ import { saleDetailPath, supplyDetailPath } from "routing/paths";
 import { designTokens, numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
+import { formatEntityId } from "utils/formatEntityId";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
@@ -149,7 +150,7 @@ export const PaymentAllocationCard: React.FC<{ payment: PaymentRecord }> = ({ pa
 								: a.allocationType === "ChangeReturn"
 									? t("payment.alloc.change")
 									: a.transactionId
-										? `${txWord} №${a.transactionId}`
+										? `${txWord} ${formatEntityId(a.transactionId)}`
 										: t("payment.alloc.settlement");
 						// Settlement rows link to the settled transaction (split sale/supply route).
 						const canOpenTx = isSettlement && a.transactionId != null && a.transactionType != null;

--- a/src/components/payment/Form/PaymentSettlementModal.tsx
+++ b/src/components/payment/Form/PaymentSettlementModal.tsx
@@ -7,6 +7,7 @@ import { OutstandingTransaction, SettlementInput } from "models/payment";
 import { designTokens, numericSx } from "theme";
 import { formatDate } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
+import { formatEntityId } from "utils/formatEntityId";
 
 import CheckIcon from "@mui/icons-material/Check";
 import SortByAlphaIcon from "@mui/icons-material/SortByAlpha";
@@ -218,7 +219,7 @@ export const PaymentSettlementModal: React.FC<PaymentSettlementModalProps> = ({
 												component="span"
 												sx={{ ...numericSx, fontWeight: 600, color: "primary.main" }}
 											>
-												№{r.id}
+												{formatEntityId(r.id)}
 											</Box>{" "}
 											<Box component="span" sx={{ color: "text.secondary", fontSize: 12 }}>
 												{t(

--- a/src/components/payment/Links/AllocationLink.tsx
+++ b/src/components/payment/Links/AllocationLink.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import DetailLink from "components/shared/Link/DetailLink";
 import { PaymentAllocation } from "models/payment";
 import { saleDetailPath, supplyDetailPath } from "routing/paths";
+import { formatEntityId } from "utils/formatEntityId";
 
 /** i18n label key per linkable allocation type (resolved at render, not import). */
 const LABEL_KEY: Record<"Sale" | "Supply" | "SaleRefund" | "SupplyRefund", string> = {
@@ -37,7 +38,9 @@ const AllocationLink: React.FC<AllocationLinkProps> = ({ allocation }) => {
 			? supplyDetailPath(transactionId)
 			: saleDetailPath(transactionId);
 
-	return <DetailLink to={to}>{`${t(LABEL_KEY[type])} №${transactionId}`}</DetailLink>;
+	return (
+		<DetailLink to={to}>{`${t(LABEL_KEY[type])} ${formatEntityId(transactionId)}`}</DetailLink>
+	);
 };
 
 export default AllocationLink;

--- a/src/components/payment/Links/PaymentLink.tsx
+++ b/src/components/payment/Links/PaymentLink.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import DetailLink from "components/shared/Link/DetailLink";
 import { paymentDetailPath } from "routing/paths";
+import { formatEntityId } from "utils/formatEntityId";
 
 interface PaymentLinkProps {
 	id: number;
@@ -8,7 +9,7 @@ interface PaymentLinkProps {
 
 /** Navigates to the payment's routed detail page. */
 const PaymentLink: React.FC<PaymentLinkProps> = ({ id }) => (
-	<DetailLink to={paymentDetailPath(id)}>№{id}</DetailLink>
+	<DetailLink to={paymentDetailPath(id)}>{formatEntityId(id)}</DetailLink>
 );
 
 export default PaymentLink;

--- a/src/components/payment/Table/PaymentsTable.tsx
+++ b/src/components/payment/Table/PaymentsTable.tsx
@@ -10,6 +10,7 @@ import { PaymentRecord } from "models/payment";
 import { numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
+import { formatEntityId } from "utils/formatEntityId";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
 import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
@@ -44,10 +45,10 @@ function buildPaymentColumns(t: TFunction): Column<PaymentRecord>[] {
 			headerName: t("payment.table.number"),
 			// The backend's legacy DTO omits the human «P-…» number — fall back to «№id»
 			// so the column is never blank (matches the detail-page title).
-			sortValue: (p) => p.number || `№${p.id}`,
+			sortValue: (p) => p.number ?? p.id,
 			renderCell: (p) => (
 				<Box component="span" sx={{ ...numericSx, fontWeight: 700, color: "primary.main" }}>
-					{p.number || `№${p.id}`}
+					{formatEntityId(p.number ?? p.id)}
 				</Box>
 			),
 		},

--- a/src/pages/PaymentDetailPage.tsx
+++ b/src/pages/PaymentDetailPage.tsx
@@ -13,6 +13,7 @@ import DetailPageHeader from "components/shared/Detail/DetailPageHeader";
 import { observer } from "mobx-react-lite";
 import { partnerDetailPath, PATHS } from "routing/paths";
 import { useStore } from "stores/StoreContext";
+import { formatEntityId } from "utils/formatEntityId";
 
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 
@@ -54,7 +55,10 @@ const PaymentDetailPage: React.FC = observer(() => {
 
 	return (
 		<Box>
-			<DetailPageHeader backTo={PATHS.payments} title={payment.number || `№${payment.id}`} />
+			<DetailPageHeader
+				backTo={PATHS.payments}
+				title={formatEntityId(payment.number ?? payment.id)}
+			/>
 
 			<Box
 				sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1fr 340px" }, gap: "20px" }}

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -11,6 +11,7 @@ import { CreatePaymentRecordRequest, PaymentRecord } from "models/payment";
 import { useStore } from "stores/StoreContext";
 import { formatDate } from "utils/dateUtils";
 import { CsvColumn, csvDateStamp, exportToCsv } from "utils/exportToCsv";
+import { formatEntityId } from "utils/formatEntityId";
 
 import { Box } from "@mui/material";
 
@@ -38,7 +39,7 @@ const PaymentPage: React.FC = observer(() => {
 	const handleExport = (): void => {
 		const rows = paymentStore.filteredPayments === "loading" ? [] : paymentStore.filteredPayments;
 		const columns: CsvColumn<PaymentRecord>[] = [
-			{ header: t("payment.table.number"), value: (p) => p.number || `№${p.id}` },
+			{ header: t("payment.table.number"), value: (p) => formatEntityId(p.number ?? p.id) },
 			{ header: t("payment.table.date"), value: (p) => formatDate(p.date) },
 			{ header: t("payment.table.type"), value: (p) => t(PAYMENT_TYPE_META[p.type].labelKey) },
 			{


### PR DESCRIPTION
Payment numbers rendered inconsistently — the served value as-is (`P-2332`) when present, an «№{id}» fallback otherwise. Routes them all through the canon `formatEntityId` helper so bare DR-21 numbers show as «№N» everywhere: payment list + detail title + CSV, allocation-card targets (`PaymentDetailCards`), `PaymentLink`, `AllocationLink`, and the settlement modal.

**Live-verified** on `:5062` (bare numbers): payments list is uniformly «№2332 / №166 / …» (no more `P-…` vs `№…` split); payment detail title «№2315»; allocation target «Продажа №1923»; no `#` anywhere.