### PR TITLE
fix(order): exact-match order-number search for DR-21 bare integers

### DIFF
--- a/src/stores/OrderStore.ts
+++ b/src/stores/OrderStore.ts
@@ -60,14 +60,16 @@ export class OrderStore {
 			list = list.filter((o) => (Date.now() - Date.parse(o.date)) / MS_PER_DAY <= days);
 		}
 
-		// Numbers display as «№…» but people also type «#…» or the bare number —
-		// strip any leading prefix from the term and match against the raw number.
+		// Numbers display as «№…» but people also type «#…» or the bare number — strip
+		// any leading prefix, then match the order number EXACTLY: DR-21 numbers are
+		// short integers, so a substring «3» would wrongly match 13/30/… Customer name
+		// stays a substring match.
 		const term = this.searchTerm.trim().toLowerCase();
 		const numberTerm = term.replace(/^[№#]/, "");
 		if (term) {
 			list = list.filter(
 				(o) =>
-					(numberTerm !== "" && o.orderNumber.toLowerCase().includes(numberTerm)) ||
+					(numberTerm !== "" && o.orderNumber === numberTerm) ||
 					o.customerName.toLowerCase().includes(term),
 			);
 		}


### PR DESCRIPTION
Order numbers are now short integers (DR-21 replaced the GUIDs). A substring search «3» wrongly matched 13/30/…; switch the order-number match to **exact equality** (leading `№`/`#` still stripped). Customer-name search stays a substring match.

The localized «Заказ №{{number}}» toast/title phrases already render correctly with bare numbers (e.g. «Заказ №4») and are left as-is — «№» reads as part of the Russian phrase, and the visible result matches `formatEntityId` everywhere else.

**Live-verified** on `:5062` (bare numbers): search «4» → only order 4 (not 74); «№4» → order 4; «7» → only order 7 (not 75/74/67).