### PR TITLE
fix(warehouse): split refund movement kinds so «Возврат» filter matches (F8)

### DIFF
--- a/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
+++ b/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
@@ -234,7 +234,9 @@ export const WarehouseMovementsTab: React.FC<WarehouseMovementsTabProps> = ({ mo
 								const unit = MEASUREMENT_SHORT[movement.measurement];
 								const isIn = movement.quantity > 0;
 								return (
-									<tr key={movement.id}>
+									<tr
+										key={`${movement.kind}-${movement.id}-${movement.productId}-${movement.date}`}
+									>
 										<td>
 											<Box
 												component="span"

--- a/src/mocks/data/warehouse.ts
+++ b/src/mocks/data/warehouse.ts
@@ -111,8 +111,8 @@ let nextMovementId = 9_000_000;
 const TXN_TO_MOVEMENT: Record<ProductMovementKind, WarehouseMovementKind> = {
 	Sale: "Sale",
 	Supply: "Supply",
-	SaleRefund: "Refund",
-	SupplyRefund: "Refund",
+	SaleRefund: "SaleRefund",
+	SupplyRefund: "SupplyRefund",
 	Opening: "Opening",
 	Transfer: "Transfer",
 	Adjustment: "Adjustment",

--- a/src/models/warehouse.ts
+++ b/src/models/warehouse.ts
@@ -59,7 +59,8 @@ export const WAREHOUSE_MOVEMENT_KINDS = [
 	"Opening",
 	"Supply",
 	"Sale",
-	"Refund",
+	"SaleRefund",
+	"SupplyRefund",
 	"Adjustment",
 	"Transfer",
 ] as const;


### PR DESCRIPTION
The FE collapsed the contract's `SaleRefund`/`SupplyRefund` `MovementKind`s into a single `"Refund"`, so the «Движения» type filter offered one «Возврат» option that matched **zero** real-backend rows (the backend serves the split kinds). Split `WAREHOUSE_MOVEMENT_KINDS` to the contract's 7 values — the chip treatment and i18n labels for both already existed. (Closes **F8**.)

Also found + fixed a keying bug on the same surface: movement rows were keyed by the raw `id`, which collides across event tables (a Transfer and an Adjustment can both be `id:1`), so a filtered-out row left a stale DOM row.

**Live-verified** on `:5062`: the type filter now offers «Возврат продажи» + «Возврат поставки»; selecting «Возврат поставки» returns exactly its 10 rows (was 0), with no stray Transfer leaking through.