### PR TITLE
fix(transaction): wire sale/supply payment rows to the payment detail (REC-6)

### DIFF
--- a/src/components/transaction/Detail/cards.tsx
+++ b/src/components/transaction/Detail/cards.tsx
@@ -486,7 +486,7 @@ const WALLET_ICON = (type: WalletType): React.ReactNode => {
 
 export const PaymentsCard: React.FC<{
 	tx: TransactionRecord;
-	onOpenPayment: (id: string) => void;
+	onOpenPayment: (paymentId: number) => void;
 }> = ({ tx, onOpenPayment }) => {
 	const { t } = useTranslation();
 	const direction = directionOf(tx.type);
@@ -505,7 +505,7 @@ export const PaymentsCard: React.FC<{
 				payments.map((p) => (
 					<Box
 						key={p.id}
-						onClick={() => onOpenPayment(p.paymentNumber)}
+						onClick={() => onOpenPayment(p.paymentId)}
 						sx={{
 							display: "flex",
 							alignItems: "center",

--- a/src/mocks/data/transaction.ts
+++ b/src/mocks/data/transaction.ts
@@ -376,6 +376,7 @@ const toPayments = (txId: number, seed: SeedPayment[] | undefined): TransactionP
 		const wallet = methodToWallet(p.method);
 		return {
 			id: nextPaymentId++,
+			paymentId: nextPaymentId,
 			transactionId: txId,
 			paymentNumber: p.id,
 			amount: p.amount,

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -24,7 +24,10 @@ export type GetTransactionsRequest = {
  * wallet the payment moved through (name + type); `paymentNumber` is the display number.
  */
 export type TransactionPaymentLine = {
+	/** Settlement-allocation id (unique per row). */
 	id: number;
+	/** Id of the source payment record — the row links to its detail page. */
+	paymentId: number;
 	transactionId: number;
 	/** Human payment number, e.g. «P-512» (shown as the row label). */
 	paymentNumber: string;

--- a/src/pages/TransactionDetailPage.tsx
+++ b/src/pages/TransactionDetailPage.tsx
@@ -16,6 +16,7 @@ import {
 import TransactionDetailHeader from "components/transaction/Detail/TransactionDetailHeader";
 import RefundModal from "components/transaction/Refund/RefundModal";
 import { observer } from "mobx-react-lite";
+import { paymentDetailPath } from "routing/paths";
 import { useStore } from "stores/StoreContext";
 import {
 	isRefundType,
@@ -140,9 +141,7 @@ const TransactionDetailPage: React.FC<TransactionDetailPageProps> = observer(({ 
 					{!refund && (
 						<PaymentsCard
 							tx={tx}
-							onOpenPayment={(pid) =>
-								devToast(`${t("transaction.detail.paymentLabel", { id: pid })}`)
-							}
+							onOpenPayment={(paymentId) => navigate(paymentDetailPath(paymentId))}
 						/>
 					)}
 				</Box>


### PR DESCRIPTION
The payments card on a sale/supply detail fired a «раздел в разработке» toast instead of navigating, because the row payload carried only `paymentNumber` (a label), not a payment id — and `TransactionPaymentDto` didn't serve one.

The backend now serves `TransactionPaymentDto.paymentId`; this threads it through `TransactionPaymentLine` and navigates the row to `paymentDetailPath(paymentId)`.

**Live-verified** on `:5062`: on sale №797, clicking the «Платёж 2268» row navigates to `/payments/5471`, which is payment 2268 (Касса · 700 000 UZS) — no more dev-toast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment entries now open their corresponding payment detail page when selected.
  * Transaction payment data now includes the linked payment identifier for accurate navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->