### PR TITLE
Wave 3 — FE convention sweeps (XC-3 / 7 / 9 / 10 / 17)

### DIFF
--- a/src/components/category/Header/CategoryHeader.tsx
+++ b/src/components/category/Header/CategoryHeader.tsx
@@ -51,7 +51,6 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("category.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 320 } }}
 				/>
 			</Box>
 		</>

--- a/src/components/debt/DebtFilters.tsx
+++ b/src/components/debt/DebtFilters.tsx
@@ -126,7 +126,6 @@ export const DebtFilters: React.FC<DebtFiltersProps> = ({
 				value={searchTerm}
 				onChange={onSearch}
 				placeholder={t("debt.searchPlaceholder")}
-				sx={{ width: { xs: "100%", sm: 300 } }}
 			/>
 
 			{tab === "transactions" && (

--- a/src/components/debt/DebtTables.tsx
+++ b/src/components/debt/DebtTables.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import PartnerLink from "components/partner/Links/PartnerLink";
 import PartnerTypeChip from "components/partner/PartnerTypeChip";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { Column, DataTable, DefaultSort } from "components/shared/Table/DataTable/DataTable";
 import { TransactionTypeBadge } from "components/transaction/TransactionBadges";
 import { Debt } from "models/debt";
@@ -320,7 +321,9 @@ export const TransactionDebtTable: React.FC<TransactionDebtTableProps> = ({
 							</Box>
 							<Box>
 								<Box component="div" sx={{ ...numericSx, fontWeight: 600, fontSize: 14 }}>
-									{formatEntityId(d.number ?? d.transactionId)}
+									<CopyableCell value={d.number ?? d.transactionId}>
+										{formatEntityId(d.number ?? d.transactionId)}
+									</CopyableCell>
 								</Box>
 								<Box component="div" sx={{ ...numericSx, fontSize: 12, color: "text.secondary" }}>
 									{formatDateTime(d.date)}

--- a/src/components/employee/Header/EmployeeHeader.tsx
+++ b/src/components/employee/Header/EmployeeHeader.tsx
@@ -68,7 +68,6 @@ const EmployeeHeader: React.FC<EmployeeHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("searchEmployeesPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 320 } }}
 				/>
 				<SegmentedControl<StatusFilter>
 					value={selectedStatus ?? "all"}

--- a/src/components/employee/Table/EmployeesTable.tsx
+++ b/src/components/employee/Table/EmployeesTable.tsx
@@ -94,17 +94,6 @@ export const EmployeesTable: React.FC<EmployeesTableProps> = ({
 				),
 			},
 			{
-				key: "salary",
-				headerName: t("employee.table.salary"),
-				align: "right",
-				sortValue: (e) => e.salary,
-				renderCell: (e) => (
-					<Box component="span" sx={{ ...numericSx, fontWeight: 700, fontSize: 15 }}>
-						{formatCurrency(e.salary)}
-					</Box>
-				),
-			},
-			{
 				key: "status",
 				headerName: t("employee.status"),
 				sortValue: (e) => t(`employee.status.${e.status}`),
@@ -120,6 +109,17 @@ export const EmployeesTable: React.FC<EmployeesTableProps> = ({
 						sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 					>
 						{formatDate(e.dateOfEmployment)}
+					</Box>
+				),
+			},
+			{
+				key: "salary",
+				headerName: t("employee.table.salary"),
+				align: "right",
+				sortValue: (e) => e.salary,
+				renderCell: (e) => (
+					<Box component="span" sx={{ ...numericSx, fontWeight: 700, fontSize: 15 }}>
+						{formatCurrency(e.salary)}
 					</Box>
 				),
 			},

--- a/src/components/order/Detail/OrderPositionsCard.tsx
+++ b/src/components/order/Detail/OrderPositionsCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import DetailCard from "components/shared/Detail/DetailCard";
 import { detailTableSx } from "components/shared/Detail/detailTableChrome";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { Order } from "models/order";
 import { designTokens, numericSx } from "theme";
 import { formatCurrency } from "utils/formatCurrency";
@@ -80,11 +81,12 @@ export const OrderPositionsCard: React.FC<{ order: Order }> = ({ order }) => {
 									<Typography component="span" sx={{ fontSize: 13.5, fontWeight: 600 }}>
 										{l.productName}
 									</Typography>
-									<Typography
+									<CopyableCell
 										sx={{ ...numericSx, fontSize: 12, color: "text.secondary", mt: "2px" }}
+										value={l.sku}
 									>
 										{l.sku}
-									</Typography>
+									</CopyableCell>
 								</td>
 								<td className="r">
 									<Box component="span" sx={numericSx}>

--- a/src/components/order/List/OrderListHeader.tsx
+++ b/src/components/order/List/OrderListHeader.tsx
@@ -68,7 +68,6 @@ export const OrderListHeader: React.FC<OrderListHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("order.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 				<OrderStatusTabs value={statusFilter} counts={statusCounts} onChange={onStatusChange} />
 				<Box sx={{ flexGrow: 1 }} />

--- a/src/components/order/List/orderColumns.tsx
+++ b/src/components/order/List/orderColumns.tsx
@@ -62,6 +62,12 @@ export function buildOrderColumns(t: TFunction): Column<Order>[] {
 			),
 		},
 		{
+			key: "delivery",
+			headerName: t("order.col.delivery"),
+			sortValue: (o) => o.deliveryDate ?? null,
+			renderCell: (o) => <OrderDeliveryCell order={o} />,
+		},
+		{
 			key: "total",
 			headerName: t("order.col.total"),
 			align: "right",
@@ -71,12 +77,6 @@ export function buildOrderColumns(t: TFunction): Column<Order>[] {
 					{formatCurrency(o.total)}
 				</Box>
 			),
-		},
-		{
-			key: "delivery",
-			headerName: t("order.col.delivery"),
-			sortValue: (o) => o.deliveryDate ?? null,
-			renderCell: (o) => <OrderDeliveryCell order={o} />,
 		},
 		{
 			key: "status",

--- a/src/components/partner/Detail/DetailTableCard.tsx
+++ b/src/components/partner/Detail/DetailTableCard.tsx
@@ -68,7 +68,7 @@ export const DetailTableCard: React.FC<DetailTableCardProps> = ({
 					value={search.value}
 					onChange={search.onChange}
 					placeholder={search.placeholder}
-					sx={{ width: { xs: "100%", sm: 240 } }}
+					dense
 				/>
 				{filters}
 				<Box sx={{ flexGrow: 1 }} />

--- a/src/components/partner/Detail/LedgerTab.tsx
+++ b/src/components/partner/Detail/LedgerTab.tsx
@@ -285,7 +285,15 @@ export const LedgerTab: React.FC<LedgerTabProps> = ({ ledger, partnerName, onOpe
 											</Box>
 										)}
 									</Box>
-									<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
+									<Box
+										component="td"
+										sx={{
+											...bodyCellSx,
+											...numericSx,
+											color: "text.secondary",
+											whiteSpace: "nowrap",
+										}}
+									>
 										{e.type === "opening" ? formatDate(e.date) : formatDateTime(e.date)}
 									</Box>
 									<Box component="td" sx={bodyCellSx}>

--- a/src/components/partner/Detail/PaymentsTab.tsx
+++ b/src/components/partner/Detail/PaymentsTab.tsx
@@ -96,8 +96,8 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 			[
 				{ header: t("partner.pays.col.date"), value: (p) => formatDate(p.date) },
 				{ header: t("partner.pays.col.type"), value: (p) => t(eventLabelKey(p.type)) },
-				{ header: t("partner.pays.col.amount"), value: (p) => Math.abs(p.delta) },
 				{ header: t("partner.pays.col.wallet"), value: (p) => p.walletName ?? "" },
+				{ header: t("partner.pays.col.amount"), value: (p) => Math.abs(p.delta) },
 			],
 			filtered,
 		);
@@ -158,6 +158,14 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 								sx={headCellSx}
 							/>
 							<DetailSortHeader
+								col="wallet"
+								label={t("partner.pays.col.wallet")}
+								active={sortCol === "wallet"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
 								col="amount"
 								label={t("partner.pays.col.amount")}
 								active={sortCol === "amount"}
@@ -165,14 +173,6 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 								onSort={onSort}
 								align="right"
 								sx={{ ...headCellSx, textAlign: "right" }}
-							/>
-							<DetailSortHeader
-								col="wallet"
-								label={t("partner.pays.col.wallet")}
-								active={sortCol === "wallet"}
-								dir={sortDir}
-								onSort={onSort}
-								sx={headCellSx}
 							/>
 						</tr>
 					</thead>
@@ -198,6 +198,13 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 								<Box component="td" sx={bodyCellSx}>
 									<EventCell type={p.type} label={t(eventLabelKey(p.type))} />
 								</Box>
+								<Box component="td" sx={{ ...bodyCellSx, fontSize: 13, color: "text.primary" }}>
+									{p.walletName ?? (
+										<Box component="span" sx={{ color: "text.secondary" }}>
+											{t("common.dash")}
+										</Box>
+									)}
+								</Box>
 								<Box
 									component="td"
 									sx={{
@@ -209,13 +216,6 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 									}}
 								>
 									{formatCurrency(Math.abs(p.delta))}
-								</Box>
-								<Box component="td" sx={{ ...bodyCellSx, fontSize: 13, color: "text.primary" }}>
-									{p.walletName ?? (
-										<Box component="span" sx={{ color: "text.secondary" }}>
-											{t("common.dash")}
-										</Box>
-									)}
 								</Box>
 							</Box>
 						))}

--- a/src/components/partner/Detail/PaymentsTab.tsx
+++ b/src/components/partner/Detail/PaymentsTab.tsx
@@ -184,7 +184,15 @@ export const PaymentsTab: React.FC<PaymentsTabProps> = ({ payments, partnerName,
 								onClick={() => onOpen(p)}
 								sx={{ cursor: "pointer", "&:hover": { bgcolor: "grey.50" } }}
 							>
-								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
+								<Box
+									component="td"
+									sx={{
+										...bodyCellSx,
+										...numericSx,
+										color: "text.secondary",
+										whiteSpace: "nowrap",
+									}}
+								>
 									{formatDateTime(p.date)}
 								</Box>
 								<Box component="td" sx={bodyCellSx}>

--- a/src/components/partner/Detail/TransactionsTab.tsx
+++ b/src/components/partner/Detail/TransactionsTab.tsx
@@ -130,9 +130,9 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 		exportToCsv<PartnerLedgerEntry>(
 			`partner_${partnerName}_transactions_${csvDateStamp()}`,
 			[
+				{ header: t("partner.txns.col.number"), value: (tx) => tx.reference ?? "" },
 				{ header: t("partner.txns.col.date"), value: (tx) => formatDate(tx.date) },
 				{ header: t("partner.txns.col.type"), value: (tx) => t(eventLabelKey(tx.type)) },
-				{ header: t("partner.txns.col.number"), value: (tx) => tx.reference ?? "" },
 				{ header: t("partner.txns.col.positions"), value: (tx) => tx.itemCount ?? "" },
 				{ header: t("partner.txns.col.amount"), value: (tx) => Math.abs(tx.delta) },
 				{
@@ -201,6 +201,14 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 					<thead>
 						<tr>
 							<DetailSortHeader
+								col="number"
+								label={t("partner.txns.col.number")}
+								active={sortCol === "number"}
+								dir={sortDir}
+								onSort={onSort}
+								sx={headCellSx}
+							/>
+							<DetailSortHeader
 								col="date"
 								label={t("partner.txns.col.date")}
 								active={sortCol === "date"}
@@ -212,14 +220,6 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 								col="type"
 								label={t("partner.txns.col.type")}
 								active={sortCol === "type"}
-								dir={sortDir}
-								onSort={onSort}
-								sx={headCellSx}
-							/>
-							<DetailSortHeader
-								col="number"
-								label={t("partner.txns.col.number")}
-								active={sortCol === "number"}
 								dir={sortDir}
 								onSort={onSort}
 								sx={headCellSx}
@@ -260,6 +260,9 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 								onClick={() => onOpen(tx)}
 								sx={{ cursor: "pointer", "&:hover": { bgcolor: "grey.50" } }}
 							>
+								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, fontWeight: 600 }}>
+									{tx.reference ?? "—"}
+								</Box>
 								<Box
 									component="td"
 									sx={{
@@ -273,9 +276,6 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 								</Box>
 								<Box component="td" sx={bodyCellSx}>
 									<EventCell type={tx.type} label={t(eventLabelKey(tx.type))} />
-								</Box>
-								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, fontWeight: 600 }}>
-									{tx.reference ?? "—"}
 								</Box>
 								<Box
 									component="td"

--- a/src/components/partner/Detail/TransactionsTab.tsx
+++ b/src/components/partner/Detail/TransactionsTab.tsx
@@ -260,7 +260,15 @@ export const TransactionsTab: React.FC<TransactionsTabProps> = ({
 								onClick={() => onOpen(tx)}
 								sx={{ cursor: "pointer", "&:hover": { bgcolor: "grey.50" } }}
 							>
-								<Box component="td" sx={{ ...bodyCellSx, ...numericSx, whiteSpace: "nowrap" }}>
+								<Box
+									component="td"
+									sx={{
+										...bodyCellSx,
+										...numericSx,
+										color: "text.secondary",
+										whiteSpace: "nowrap",
+									}}
+								>
 									{formatDateTime(tx.date)}
 								</Box>
 								<Box component="td" sx={bodyCellSx}>

--- a/src/components/partner/List/PartnerListHeader.tsx
+++ b/src/components/partner/List/PartnerListHeader.tsx
@@ -64,7 +64,6 @@ export const PartnerListHeader: React.FC<PartnerListHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("partner.list.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 320 } }}
 				/>
 				<SegmentedControl<PartnerTypeFilter>
 					value={typeFilter}

--- a/src/components/payment/Header/PaymentHeader.tsx
+++ b/src/components/payment/Header/PaymentHeader.tsx
@@ -84,7 +84,6 @@ const PaymentHeader: React.FC<PaymentHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("payment.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 350 } }}
 				/>
 				<PaymentFilterDropdown
 					icon={<LayersOutlinedIcon sx={{ fontSize: 15 }} />}

--- a/src/components/payment/Table/PaymentsTable.tsx
+++ b/src/components/payment/Table/PaymentsTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import PartnerLink from "components/partner/Links/PartnerLink";
 import { PaymentDirectionBadge, PaymentTypeBadge } from "components/payment/PaymentPresentation";
+import { CopyableNumberCell } from "components/shared/Table/CopyableNumberCell";
 import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
 import WalletLink from "components/wallet/Links/WalletLink";
 import { Loadable } from "helpers/Loading";
@@ -10,7 +11,6 @@ import { PaymentRecord } from "models/payment";
 import { numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency } from "utils/formatCurrency";
-import { formatEntityId } from "utils/formatEntityId";
 
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
 import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
@@ -46,11 +46,7 @@ function buildPaymentColumns(t: TFunction): Column<PaymentRecord>[] {
 			// The backend's legacy DTO omits the human «P-…» number — fall back to «№id»
 			// so the column is never blank (matches the detail-page title).
 			sortValue: (p) => p.number ?? p.id,
-			renderCell: (p) => (
-				<Box component="span" sx={{ ...numericSx, fontWeight: 700, color: "primary.main" }}>
-					{formatEntityId(p.number ?? p.id)}
-				</Box>
-			),
+			renderCell: (p) => <CopyableNumberCell value={p.number ?? p.id} />,
 		},
 		{
 			key: "date",

--- a/src/components/product/Detail/ProductDetailRail.tsx
+++ b/src/components/product/Detail/ProductDetailRail.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import DetailCard from "components/shared/Detail/DetailCard";
 import UzsUnit from "components/shared/Money/UzsUnit";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { Product } from "models/product";
 import { designTokens, numericSx } from "theme";
 import { formatCurrency } from "utils/formatCurrency";
@@ -89,8 +90,14 @@ export const ProductDetailRail: React.FC<ProductDetailRailProps> = ({ product })
 		: "—";
 
 	const infoRows = [
-		{ id: "sku", label: t("product.sku"), value: product.sku, mono: true },
-		{ id: "barcode", label: t("product.barcode"), value: product.barcode || "—", mono: true },
+		{ id: "sku", label: t("product.sku"), value: product.sku, mono: true, copyable: true },
+		{
+			id: "barcode",
+			label: t("product.barcode"),
+			value: product.barcode || "—",
+			mono: true,
+			copyable: !!product.barcode,
+		},
 		{ id: "category", label: t("product.category"), value: product.categoryName ?? "—" },
 		{ id: "type", label: t("product.type"), value: t(`product.typeLong.${product.type}`) },
 		{
@@ -139,21 +146,27 @@ export const ProductDetailRail: React.FC<ProductDetailRailProps> = ({ product })
 				icon={<InfoOutlinedIcon sx={{ fontSize: 17, color: "text.secondary" }} />}
 			>
 				<Box sx={{ p: "6px 18px 14px" }}>
-					{infoRows.map((row) => (
-						<Row key={row.id} label={row.label}>
-							<Typography
-								component="span"
-								sx={{
-									fontSize: 13.5,
-									fontWeight: 500,
-									textAlign: "right",
-									...(row.mono ? numericSx : null),
-								}}
-							>
-								{row.value}
-							</Typography>
-						</Row>
-					))}
+					{infoRows.map((row) => {
+						const valueSx = {
+							fontSize: 13.5,
+							fontWeight: 500,
+							textAlign: "right" as const,
+							...(row.mono ? numericSx : null),
+						};
+						return (
+							<Row key={row.id} label={row.label}>
+								{"copyable" in row && row.copyable ? (
+									<CopyableCell value={row.value} sx={valueSx}>
+										{row.value}
+									</CopyableCell>
+								) : (
+									<Typography component="span" sx={valueSx}>
+										{row.value}
+									</Typography>
+								)}
+							</Row>
+						);
+					})}
 				</Box>
 			</DetailCard>
 		</Stack>

--- a/src/components/product/Detail/ProductOverviewTab.tsx
+++ b/src/components/product/Detail/ProductOverviewTab.tsx
@@ -86,7 +86,8 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 									sx={{
 										...numericSx,
 										fontSize: 11.5,
-										color: "text.disabled",
+										fontWeight: 600,
+										color: "text.secondary",
 										mt: "6px",
 										textAlign: "center",
 										overflow: "hidden",

--- a/src/components/product/Detail/ProductOverviewTab.tsx
+++ b/src/components/product/Detail/ProductOverviewTab.tsx
@@ -133,8 +133,8 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 					<thead>
 						<tr>
 							<th>{t("product.detail.table.warehouse")}</th>
-							<th className="r">{t("product.detail.table.quantity")}</th>
 							<th>{t("product.detail.table.unit")}</th>
+							<th className="r">{t("product.detail.table.quantity")}</th>
 							<th className="r">{t("product.detail.table.wac")}</th>
 							<th className="r">{t("product.detail.table.value")}</th>
 						</tr>
@@ -145,6 +145,11 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 								<td>
 									<WarehouseLink id={item.warehouseId} name={item.warehouseName} />
 								</td>
+								<td>
+									<Box component="span" sx={{ color: "text.secondary" }}>
+										{unit}
+									</Box>
+								</td>
 								<td className="r">
 									<Box
 										component="span"
@@ -154,11 +159,6 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 										}}
 									>
 										{formatQuantity(item.quantity)}
-									</Box>
-								</td>
-								<td>
-									<Box component="span" sx={{ color: "text.secondary" }}>
-										{unit}
 									</Box>
 								</td>
 								<td className="r">
@@ -175,6 +175,7 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 						))}
 						<tr className="total">
 							<td>{t("product.detail.table.total")}</td>
+							<td></td>
 							<td className="r">
 								<Box
 									component="span"
@@ -187,7 +188,6 @@ export const ProductOverviewTab: React.FC<ProductOverviewTabProps> = ({ product 
 									{formatQuantity(product.totalStock)}
 								</Box>
 							</td>
-							<td></td>
 							<td className="r">
 								<Box component="span" sx={{ ...numericSx, fontWeight: 800 }}>
 									{product.averageCost != null ? formatCurrency(product.averageCost) : "—"}

--- a/src/components/product/Detail/ProductTransactionsTab.tsx
+++ b/src/components/product/Detail/ProductTransactionsTab.tsx
@@ -1,20 +1,18 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 import PartnerLink from "components/partner/Links/PartnerLink";
 import DetailCard from "components/shared/Detail/DetailCard";
 import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
 import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
+import TablePager from "components/shared/Table/TablePager";
 import { Measurement, ProductTransaction } from "models/product";
-import { PATHS } from "routing/paths";
-import { designTokens, numericSx } from "theme";
+import { numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
 import { formatCurrency, formatQuantity } from "utils/formatCurrency";
 import { unitInline } from "utils/productUtils";
 
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import SwapHorizOutlinedIcon from "@mui/icons-material/SwapHorizOutlined";
-import { Box, Link } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { cardIconSx, detailTableSx, quantityInSx, quantityOutSx } from "./detailTableSx";
 import HistoryEmptyState from "./HistoryEmptyState";
@@ -34,10 +32,11 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 	measurement,
 }) => {
 	const { t } = useTranslation();
-	const navigate = useNavigate();
 	const unit = unitInline(t, measurement);
 	const [sortCol, setSortCol] = useState<SortCol>("date");
 	const [sortDir, setSortDir] = useState<SortDir>("desc");
+	const [page, setPage] = useState(0);
+	const [rowsPerPage, setRowsPerPage] = useState(10);
 
 	const rows = useMemo(() => {
 		const accessor = (txn: ProductTransaction): string | number => {
@@ -61,6 +60,8 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 		const sorted = [...transactions].sort((a, b) => compareValues(accessor(a), accessor(b)));
 		return sortDir === "desc" ? sorted.reverse() : sorted;
 	}, [transactions, sortCol, sortDir]);
+
+	const paged = rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
 	const onSort = (col: SortCol) => {
 		if (col === sortCol) {
@@ -135,7 +136,7 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 							</tr>
 						</thead>
 						<tbody>
-							{rows.map((txn) => (
+							{paged.map((txn) => (
 								<tr key={txn.id}>
 									<td>
 										<Box component="span" sx={{ ...numericSx, color: "text.secondary" }}>
@@ -168,34 +169,16 @@ export const ProductTransactionsTab: React.FC<ProductTransactionsTabProps> = ({
 							))}
 						</tbody>
 					</Box>
-					{/* Warm footer band matching the total-row band of the Stocks /
-					    Movements tabs (so all three tabs read identically). */}
-					<Box
-						sx={{
-							px: "18px",
-							py: "12px",
-							bgcolor: designTokens.gray25,
-							borderTop: "1.5px solid",
-							borderColor: designTokens.gray300,
+					<TablePager
+						count={rows.length}
+						page={page}
+						rowsPerPage={rowsPerPage}
+						onPageChange={setPage}
+						onRowsPerPageChange={(n) => {
+							setRowsPerPage(n);
+							setPage(0);
 						}}
-					>
-						<Link
-							component="button"
-							underline="hover"
-							onClick={() => navigate(PATHS.sales)}
-							sx={{
-								display: "inline-flex",
-								alignItems: "center",
-								gap: "2px",
-								color: "primary.main",
-								fontSize: 13.5,
-								fontWeight: 600,
-							}}
-						>
-							{t("product.detail.txns.all")}
-							<ChevronRightIcon sx={{ fontSize: 16 }} />
-						</Link>
-					</Box>
+					/>
 				</>
 			)}
 		</DetailCard>

--- a/src/components/product/Header/ProductHeader.tsx
+++ b/src/components/product/Header/ProductHeader.tsx
@@ -82,7 +82,6 @@ const ProductHeader: React.FC<ProductHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("product.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 
 				{/* Entity filters are typeahead (convention); small fixed sets stay tabs. */}

--- a/src/components/product/Table/productsTableConfigs.tsx
+++ b/src/components/product/Table/productsTableConfigs.tsx
@@ -1,6 +1,7 @@
 import ProductTypeChip from "components/product/ProductTypeChip";
 import { ProductActionMenu } from "components/product/Table/ActionMenu/ProductActionMenu";
 import ArchivedBadge from "components/shared/ArchivedBadge/ArchivedBadge";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { Column } from "components/shared/Table/DataTable/DataTable";
 import { ACTIONS_COLUMN_WIDTH } from "components/shared/Table/DataTable/tableConfigs";
 import TruncatedText from "components/shared/Table/TruncatedText";
@@ -99,8 +100,8 @@ export function buildProductColumns({
 			headerName: t("product.table.sku"),
 			width: "12%",
 			renderCell: (product) => (
-				<Typography
-					component="span"
+				<CopyableCell
+					value={product.sku}
 					sx={{
 						...numericSx,
 						fontSize: 12.5,
@@ -110,7 +111,7 @@ export function buildProductColumns({
 					}}
 				>
 					{product.sku}
-				</Typography>
+				</CopyableCell>
 			),
 		},
 		{

--- a/src/components/shared/SearchInput/SearchInput.tsx
+++ b/src/components/shared/SearchInput/SearchInput.tsx
@@ -11,6 +11,12 @@ export interface SearchInputProps {
 	onChange: (value: string) => void;
 	placeholder: string;
 	className?: string;
+	/**
+	 * Compact width (sm:280) for in-card table toolbars that share a bordered band
+	 * with filters/export, where the standard sm:350 would wrap. Page-level toolbars
+	 * omit it and get the standard width. Ignored when an explicit `sx` is passed.
+	 */
+	dense?: boolean;
 	sx?: SxProps;
 }
 
@@ -19,8 +25,10 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 	onChange,
 	placeholder,
 	className = "",
-	sx = { width: { xs: "100%", sm: 350 } },
+	dense = false,
+	sx,
 }) => {
+	const widthSx = sx ?? { width: { xs: "100%", sm: dense ? 280 : 350 } };
 	return (
 		<TextField
 			className={className}
@@ -30,7 +38,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 				// Bundle .search-box: surface bg with the strong border.
 				"& .MuiOutlinedInput-root": { bgcolor: "background.paper" },
 				"& .MuiOutlinedInput-notchedOutline": { borderColor: designTokens.gray300 },
-				...sx,
+				...widthSx,
 			}}
 			placeholder={placeholder}
 			value={value}

--- a/src/components/shared/Table/CopyableCell.tsx
+++ b/src/components/shared/Table/CopyableCell.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Box, SxProps, Theme, Tooltip } from "@mui/material";
+
+export interface CopyableCellProps {
+	/** Raw value written to the clipboard on click. */
+	value: string | number;
+	/** Display node; defaults to `String(value)`. */
+	children?: React.ReactNode;
+	/** Styling merged over the base copy affordance (cursor + hover underline). */
+	sx?: SxProps<Theme>;
+}
+
+/**
+ * Shared click-to-copy text cell — the single copy affordance behind every
+ * identifier cell (XC-7 "one text-cell formatter"). It copies the raw `value`,
+ * swallows its own clicks (including the mouseup that ends a text selection) so
+ * a clickable row's open-detail navigation never fires, shows a copy/copied
+ * tooltip and flashes success on copy. Callers own the DISPLAY: pass the text as
+ * children and its styling via `sx`. {@link CopyableNumberCell} wraps this for
+ * «№…» entity ids; SKU / reference cells use it directly with their own muted
+ * mono styling (no «№» prefix).
+ */
+export const CopyableCell: React.FC<CopyableCellProps> = ({ value, children, sx }) => {
+	const { t } = useTranslation();
+	const [copied, setCopied] = useState(false);
+
+	const copy = async (e: React.MouseEvent) => {
+		e.stopPropagation();
+		try {
+			await navigator.clipboard.writeText(String(value));
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1200);
+		} catch {
+			/* clipboard unavailable — no-op */
+		}
+	};
+
+	return (
+		<Tooltip title={copied ? t("common.copied") : t("common.copy")} placement="top">
+			<Box
+				component="span"
+				onClick={copy}
+				sx={{
+					cursor: "copy",
+					"&:hover": { textDecoration: "underline" },
+					...sx,
+					// The copied flash must win over the caller's resting color.
+					...(copied ? { color: "success.main" } : null),
+				}}
+			>
+				{children ?? String(value)}
+			</Box>
+		</Tooltip>
+	);
+};
+
+export default CopyableCell;

--- a/src/components/shared/Table/CopyableNumberCell.tsx
+++ b/src/components/shared/Table/CopyableNumberCell.tsx
@@ -1,54 +1,25 @@
-import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
+import React from "react";
 import { designTokens, numericSx } from "theme";
 import { formatEntityId } from "utils/formatEntityId";
 
-import { Box, Tooltip } from "@mui/material";
+import { CopyableCell } from "./CopyableCell";
 
 /**
  * Entity-number list cell: shows the served number as «№…» and copies the raw
- * number on click. It swallows its clicks (including the mouseup that ends a
- * text selection) so interacting with the number never triggers the row's
- * open-detail navigation — the rest of the row stays clickable. `muted` is the
- * toned-down variant for rows whose number is secondary (e.g. refunds).
+ * number on click (via {@link CopyableCell}, which swallows the click so the
+ * row's open-detail never fires). `muted` is the toned-down variant for rows
+ * whose number is secondary (e.g. refunds).
  */
 export const CopyableNumberCell: React.FC<{ value: string | number; muted?: boolean }> = ({
 	value,
 	muted = false,
-}) => {
-	const { t } = useTranslation();
-	const [copied, setCopied] = useState(false);
-
-	const copy = async (e: React.MouseEvent) => {
-		e.stopPropagation();
-		try {
-			await navigator.clipboard.writeText(String(value));
-			setCopied(true);
-			setTimeout(() => setCopied(false), 1200);
-		} catch {
-			/* clipboard unavailable — no-op */
-		}
-	};
-
-	const restingColor = muted ? designTokens.gray700 : "primary.main";
-
-	return (
-		<Tooltip title={copied ? t("common.copied") : t("common.copy")} placement="top">
-			<Box
-				component="span"
-				onClick={copy}
-				sx={{
-					...numericSx,
-					fontWeight: 700,
-					color: copied ? "success.main" : restingColor,
-					cursor: "copy",
-					"&:hover": { textDecoration: "underline" },
-				}}
-			>
-				{formatEntityId(value)}
-			</Box>
-		</Tooltip>
-	);
-};
+}) => (
+	<CopyableCell
+		value={value}
+		sx={{ ...numericSx, fontWeight: 700, color: muted ? designTokens.gray700 : "primary.main" }}
+	>
+		{formatEntityId(value)}
+	</CopyableCell>
+);
 
 export default CopyableNumberCell;

--- a/src/components/stockAdjustment/Header/StockAdjustmentHeader.tsx
+++ b/src/components/stockAdjustment/Header/StockAdjustmentHeader.tsx
@@ -76,7 +76,6 @@ const StockAdjustmentHeader: React.FC<StockAdjustmentHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("adjustment.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 280 } }}
 				/>
 
 				<TextField

--- a/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
+++ b/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import ProductLink from "components/product/Links/ProductLink";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import {
 	Column,
 	ExpandableDataTable,
@@ -113,7 +114,7 @@ const AdjustmentDetail: React.FC<{ adjustment: StockAdjustment }> = ({ adjustmen
 					}}
 				>
 					<ExpandField label={t("adjustment.table.sku")} mono>
-						{adjustment.sku}
+						<CopyableCell value={adjustment.sku}>{adjustment.sku}</CopyableCell>
 					</ExpandField>
 					<ExpandField label={t("adjustment.table.category")}>
 						{adjustment.categoryName ?? "—"}

--- a/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
+++ b/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
@@ -199,7 +199,7 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 				renderCell: (a) => (
 					<Box
 						component="span"
-						sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
+						sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 					>
 						{formatDateTime(a.date)}
 					</Box>

--- a/src/components/template/Header/TemplateHeader.tsx
+++ b/src/components/template/Header/TemplateHeader.tsx
@@ -59,7 +59,6 @@ const TemplateHeader: React.FC<TemplateHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("template.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 340 } }}
 				/>
 				<SegmentedControl<TemplateTypeFilter>
 					options={typeOptions}

--- a/src/components/template/Table/TemplatesTable.tsx
+++ b/src/components/template/Table/TemplatesTable.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import PartnerLink from "components/partner/Links/PartnerLink";
 import ProductLink from "components/product/Links/ProductLink";
 import ActionMenu from "components/shared/ActionMenuCell/MenuActionCell";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import {
 	Column,
 	ExpandableDataTable,
@@ -155,9 +156,12 @@ const TemplateItemsDetail: React.FC<{ template: Template }> = ({ template }) => 
 								</Box>
 							</Box>
 							<Box component="td" sx={innerBodySx}>
-								<Box component="span" sx={{ ...numericSx, fontSize: 12.5, color: "text.disabled" }}>
+								<CopyableCell
+									value={item.sku}
+									sx={{ ...numericSx, fontSize: 12.5, color: "text.disabled" }}
+								>
 									{item.sku}
-								</Box>
+								</CopyableCell>
 							</Box>
 							<Box component="td" sx={{ ...innerBodySx, textAlign: "right" }}>
 								<Box component="span" sx={numericSx}>

--- a/src/components/transaction/Detail/cards.tsx
+++ b/src/components/transaction/Detail/cards.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import PartnerLink from "components/partner/Links/PartnerLink";
 import MetaDot from "components/shared/Detail/MetaDot";
+import { CopyableNumberCell } from "components/shared/Table/CopyableNumberCell";
 import { TransactionStatusChip } from "components/transaction/TransactionBadges";
 import { TransactionLine, TransactionRecord, TransactionStatus } from "models/transaction";
 import { WalletType } from "models/wallet";
@@ -613,16 +614,8 @@ export const RefundHistoryCard: React.FC<{
 							<Box component="td" sx={{ ...bodyCellSx, textAlign: "left", pl: "18px" }}>
 								{formatDateTime(r.date)}
 							</Box>
-							<Box
-								component="td"
-								sx={{
-									...bodyCellSx,
-									textAlign: "left",
-									fontWeight: 700,
-									color: designTokens.gray700,
-								}}
-							>
-								{formatEntityId(r.transactionNumber ?? r.id)}
+							<Box component="td" sx={{ ...bodyCellSx, textAlign: "left" }}>
+								<CopyableNumberCell value={r.transactionNumber ?? r.id} muted />
 							</Box>
 							<Box component="td" sx={{ ...bodyCellSx, textAlign: "left" }}>
 								{r.lines.length}

--- a/src/components/transaction/List/TransactionListHeader.tsx
+++ b/src/components/transaction/List/TransactionListHeader.tsx
@@ -63,7 +63,6 @@ export const TransactionListHeader: React.FC<TransactionListHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t(`transaction.list.search.${direction}`)}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 				<SegmentedControl<StatusFilter>
 					value={statusFilter}

--- a/src/components/transaction/List/transactionColumns.tsx
+++ b/src/components/transaction/List/transactionColumns.tsx
@@ -70,10 +70,7 @@ export function buildTransactionColumns(t: TFunction): Column<TransactionRecord>
 			// feed order). 0.5 is exact in float64 and never overtakes another timestamp.
 			sortValue: (tx) => tx.date.getTime() + (isRefundType(tx.type) ? 0.5 : 0),
 			renderCell: (tx) => (
-				<Box
-					component="span"
-					sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
-				>
+				<Box component="span" sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}>
 					{formatDateTime(tx.date)}
 				</Box>
 			),

--- a/src/components/transfer/Detail/TransferDetailModal.tsx
+++ b/src/components/transfer/Detail/TransferDetailModal.tsx
@@ -144,7 +144,7 @@ export const TransferDetailModal: React.FC<TransferDetailModalProps> = ({ transf
 									</CopyableCell>
 								</td>
 								<td className="r">
-									<Box component="span" sx={{ ...numericSx, fontWeight: 700 }}>
+									<Box component="span" sx={{ ...numericSx }}>
 										{formatQuantity(line.quantity)}
 									</Box>
 								</td>
@@ -159,7 +159,7 @@ export const TransferDetailModal: React.FC<TransferDetailModalProps> = ({ transf
 							<td>{t("transfer.detail.totalPositions", { positions: transfer.lines.length })}</td>
 							<td />
 							<td className="r">
-								<Box component="span" sx={{ ...numericSx, fontWeight: 800 }}>
+								<Box component="span" sx={{ ...numericSx, fontWeight: 700 }}>
 									{formatQuantity(transferUnits(transfer))}
 								</Box>
 							</td>

--- a/src/components/transfer/Detail/TransferDetailModal.tsx
+++ b/src/components/transfer/Detail/TransferDetailModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { detailTableSx } from "components/product/Detail/detailTableSx";
 import GhostButton from "components/shared/Buttons/GhostButton";
 import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { Transfer, transferUnits } from "models/transfer";
 import { designTokens, numericSx } from "theme";
 import { formatDateTime } from "utils/dateUtils";
@@ -135,9 +136,12 @@ export const TransferDetailModal: React.FC<TransferDetailModalProps> = ({ transf
 									</Box>
 								</td>
 								<td>
-									<Box component="span" sx={{ ...numericSx, fontSize: 12, color: "text.disabled" }}>
+									<CopyableCell
+										value={line.sku}
+										sx={{ ...numericSx, fontSize: 12, color: "text.disabled" }}
+									>
 										{line.sku}
-									</Box>
+									</CopyableCell>
 								</td>
 								<td className="r">
 									<Box component="span" sx={{ ...numericSx, fontWeight: 700 }}>

--- a/src/components/transfer/Detail/TransferDetailModal.tsx
+++ b/src/components/transfer/Detail/TransferDetailModal.tsx
@@ -109,67 +109,68 @@ export const TransferDetailModal: React.FC<TransferDetailModalProps> = ({ transf
 
 				{/* lines */}
 				<Box
-					component="table"
 					sx={{
-						...detailTableSx,
 						border: "1px solid",
 						borderColor: "divider",
 						borderRadius: "8px",
+						overflow: "hidden",
 					}}
 				>
-					<thead>
-						<tr>
-							<Box component="th">{t("transfer.table.product")}</Box>
-							<Box component="th">{t("transfer.table.sku")}</Box>
-							<Box component="th" className="r">
-								{t("transfer.table.quantity")}
-							</Box>
-							<Box component="th">{t("transfer.table.unit")}</Box>
-						</tr>
-					</thead>
-					<tbody>
-						{transfer.lines.map((line) => (
-							<tr key={line.productId}>
-								<td>
-									<Box component="span" sx={{ fontWeight: 600 }}>
-										{line.productName}
-									</Box>
-								</td>
-								<td>
-									<CopyableCell
-										value={line.sku}
-										sx={{ ...numericSx, fontSize: 12, color: "text.disabled" }}
-									>
-										{line.sku}
-									</CopyableCell>
-								</td>
+					<Box component="table" sx={detailTableSx}>
+						<thead>
+							<tr>
+								<Box component="th">{t("transfer.table.product")}</Box>
+								<Box component="th">{t("transfer.table.sku")}</Box>
+								<Box component="th" className="r">
+									{t("transfer.table.quantity")}
+								</Box>
+								<Box component="th">{t("transfer.table.unit")}</Box>
+							</tr>
+						</thead>
+						<tbody>
+							{transfer.lines.map((line) => (
+								<tr key={line.productId}>
+									<td>
+										<Box component="span" sx={{ fontWeight: 600 }}>
+											{line.productName}
+										</Box>
+									</td>
+									<td>
+										<CopyableCell
+											value={line.sku}
+											sx={{ ...numericSx, fontSize: 12, color: "text.disabled" }}
+										>
+											{line.sku}
+										</CopyableCell>
+									</td>
+									<td className="r">
+										<Box component="span" sx={{ ...numericSx }}>
+											{formatQuantity(line.quantity)}
+										</Box>
+									</td>
+									<td>
+										<Box component="span" sx={{ color: "text.secondary" }}>
+											{MEASUREMENT_SHORT[line.measurement]}
+										</Box>
+									</td>
+								</tr>
+							))}
+							<tr className="total">
+								<td>{t("transfer.detail.totalPositions", { positions: transfer.lines.length })}</td>
+								<td />
 								<td className="r">
-									<Box component="span" sx={{ ...numericSx }}>
-										{formatQuantity(line.quantity)}
+									<Box component="span" sx={{ ...numericSx, fontWeight: 700 }}>
+										{formatQuantity(transferUnits(transfer))}
 									</Box>
 								</td>
 								<td>
 									<Box component="span" sx={{ color: "text.secondary" }}>
-										{MEASUREMENT_SHORT[line.measurement]}
+										{t("transfer.unitFallback")}
 									</Box>
 								</td>
 							</tr>
-						))}
-						<tr className="total">
-							<td>{t("transfer.detail.totalPositions", { positions: transfer.lines.length })}</td>
-							<td />
-							<td className="r">
-								<Box component="span" sx={{ ...numericSx, fontWeight: 700 }}>
-									{formatQuantity(transferUnits(transfer))}
-								</Box>
-							</td>
-							<td>
-								<Box component="span" sx={{ color: "text.secondary" }}>
-									{t("transfer.unitFallback")}
-								</Box>
-							</td>
-						</tr>
-					</tbody>
+						</tbody>
+					</Box>
 				</Box>
 
 				{transfer.note && (

--- a/src/components/transfer/Header/TransferHeader.tsx
+++ b/src/components/transfer/Header/TransferHeader.tsx
@@ -68,7 +68,6 @@ const TransferHeader: React.FC<TransferHeaderProps> = ({
 					value={search}
 					onChange={onSearchChange}
 					placeholder={t("transfer.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 				<TextField
 					select

--- a/src/components/transfer/Table/transfersTableConfigs.tsx
+++ b/src/components/transfer/Table/transfersTableConfigs.tsx
@@ -50,7 +50,7 @@ export function buildTransferColumns(t: TFunction): Column<Transfer>[] {
 			renderCell: (transfer) => (
 				<Typography
 					component="span"
-					sx={{ ...numericSx, color: designTokens.gray700, whiteSpace: "nowrap" }}
+					sx={{ ...numericSx, color: "text.secondary", whiteSpace: "nowrap" }}
 				>
 					{formatDateTime(transfer.date)}
 				</Typography>

--- a/src/components/wallet/Detail/WalletOperationsTab.tsx
+++ b/src/components/wallet/Detail/WalletOperationsTab.tsx
@@ -206,7 +206,6 @@ export const WalletOperationsTab: React.FC<WalletOperationsTabProps> = ({
 					value={query}
 					onChange={setQuery}
 					placeholder={t("wallet.operations.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 				<SegmentedControl options={dirOptions} value={dir} onChange={setDir} />
 			</Box>

--- a/src/components/wallet/Detail/WalletTransfersTab.tsx
+++ b/src/components/wallet/Detail/WalletTransfersTab.tsx
@@ -85,6 +85,16 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 				),
 			},
 			{
+				key: "createdBy",
+				headerName: t("wallet.transfers.createdBy"),
+				sortValue: (tr) => tr.createdBy,
+				renderCell: (tr) => (
+					<Box component="span" sx={{ color: "text.secondary" }}>
+						{tr.createdBy}
+					</Box>
+				),
+			},
+			{
 				key: "amount",
 				headerName: t("wallet.transfers.amount"),
 				align: "right",
@@ -92,16 +102,6 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 				renderCell: (tr) => (
 					<Box component="span" sx={{ ...numericSx, fontWeight: 700, fontSize: 15 }}>
 						{formatCurrency(tr.amount)}
-					</Box>
-				),
-			},
-			{
-				key: "createdBy",
-				headerName: t("wallet.transfers.createdBy"),
-				sortValue: (tr) => tr.createdBy,
-				renderCell: (tr) => (
-					<Box component="span" sx={{ color: "text.secondary" }}>
-						{tr.createdBy}
 					</Box>
 				),
 			},

--- a/src/components/wallet/Detail/WalletTransfersTab.tsx
+++ b/src/components/wallet/Detail/WalletTransfersTab.tsx
@@ -154,7 +154,6 @@ export const WalletTransfersTab: React.FC<WalletTransfersTabProps> = ({
 					value={query}
 					onChange={setQuery}
 					placeholder={t("wallet.transfers.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 300 } }}
 				/>
 			</Box>
 			<DataTable<WalletTransfer>

--- a/src/components/wallet/Header/WalletHeader.tsx
+++ b/src/components/wallet/Header/WalletHeader.tsx
@@ -63,7 +63,6 @@ const WalletHeader: React.FC<WalletHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("wallet.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 320 } }}
 				/>
 
 				<Box sx={{ flexGrow: 1 }} />

--- a/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
+++ b/src/components/warehouse/Detail/WarehouseMovementsTab.tsx
@@ -120,7 +120,7 @@ export const WarehouseMovementsTab: React.FC<WarehouseMovementsTabProps> = ({ mo
 					value={query}
 					onChange={setQuery}
 					placeholder={t("warehouse.movements.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 240 } }}
+					dense
 				/>
 				<TextField
 					select

--- a/src/components/warehouse/Detail/WarehouseStockTab.tsx
+++ b/src/components/warehouse/Detail/WarehouseStockTab.tsx
@@ -5,6 +5,7 @@ import DetailCard from "components/shared/Detail/DetailCard";
 import DetailSortHeader, { SortDir } from "components/shared/Detail/DetailSortHeader";
 import { detailTableSx } from "components/shared/Detail/detailTableChrome";
 import { SearchInput } from "components/shared/SearchInput/SearchInput";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
 import { compareValues } from "components/shared/Table/DataTable/tableConfigs";
 import TablePager from "components/shared/Table/TablePager";
 import { Warehouse, WarehouseStockItem } from "models/warehouse";
@@ -232,12 +233,12 @@ export const WarehouseStockTab: React.FC<WarehouseStockTabProps> = ({ warehouse,
 										<ProductLink id={item.productId} name={item.productName} />
 									</td>
 									<td>
-										<Box
-											component="span"
+										<CopyableCell
+											value={item.sku}
 											sx={{ ...numericSx, fontSize: 12, color: "text.secondary" }}
 										>
 											{item.sku}
-										</Box>
+										</CopyableCell>
 									</td>
 									<td>
 										<Box component="span" sx={{ color: "text.secondary" }}>

--- a/src/components/warehouse/Detail/WarehouseStockTab.tsx
+++ b/src/components/warehouse/Detail/WarehouseStockTab.tsx
@@ -111,7 +111,7 @@ export const WarehouseStockTab: React.FC<WarehouseStockTabProps> = ({ warehouse,
 					value={query}
 					onChange={setQuery}
 					placeholder={t("warehouse.stock.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 280 } }}
+					dense
 				/>
 				<TextField
 					select

--- a/src/components/warehouse/Header/WarehouseHeader.tsx
+++ b/src/components/warehouse/Header/WarehouseHeader.tsx
@@ -69,7 +69,6 @@ const WarehouseHeader: React.FC<WarehouseHeaderProps> = ({
 					value={searchValue}
 					onChange={onSearch}
 					placeholder={t("warehouse.searchPlaceholder")}
-					sx={{ width: { xs: "100%", sm: 320 } }}
 				/>
 
 				<Box sx={{ flexGrow: 1 }} />

--- a/src/i18n/ru/product.json
+++ b/src/i18n/ru/product.json
@@ -71,7 +71,6 @@
   "product.detail.txns.partner": "Партнёр",
   "product.detail.txns.price": "Цена",
   "product.detail.txns.total": "Сумма",
-  "product.detail.txns.all": "Все транзакции",
   "product.detail.txns.emptyTitle": "Нет записей",
   "product.detail.txns.emptyBody": "По этому товару ещё не было продаж, поставок или возвратов.",
   "product.detail.moves.title": "Движения по складу",

--- a/src/pages/EmployeeDetailPage.tsx
+++ b/src/pages/EmployeeDetailPage.tsx
@@ -159,17 +159,6 @@ const EmployeeDetailPage: React.FC = observer(() => {
 				),
 			},
 			{
-				key: "amount",
-				headerName: t("employee.payroll.amount"),
-				align: "right",
-				sortValue: (p) => p.amount,
-				renderCell: (p) => (
-					<Box component="span" sx={{ ...numericSx, fontWeight: 700, fontSize: 15 }}>
-						{formatCurrency(p.amount)}
-					</Box>
-				),
-			},
-			{
 				key: "wallet",
 				headerName: t("employee.payroll.wallet"),
 				sortValue: (p) => p.walletName ?? "",
@@ -181,6 +170,17 @@ const EmployeeDetailPage: React.FC = observer(() => {
 							—
 						</Box>
 					),
+			},
+			{
+				key: "amount",
+				headerName: t("employee.payroll.amount"),
+				align: "right",
+				sortValue: (p) => p.amount,
+				renderCell: (p) => (
+					<Box component="span" sx={{ ...numericSx, fontWeight: 700, fontSize: 15 }}>
+						{formatCurrency(p.amount)}
+					</Box>
+				),
 			},
 		],
 		[t],


### PR DESCRIPTION
Frontend convention sweeps from `issues-tracker.md`, batched into one PR of five per-chunk commits (each individually revertable). All live-verified on `http://localhost:3000` against the real backend.

### Commits
- **`polish(search)` — XC-3 searchbox width.** One standard instead of six ad-hoc widths: the shared `SearchInput` 350 default governs page toolbars; a new `dense` (280) variant covers the in-card `DetailCard` bands (partner ledger, warehouse stock/movements) where 350 wrapped the row. Verified the partner ledger no longer wraps its Export button at 1280.
- **`polish(tables)` — XC-7 click-to-copy.** New shared `CopyableCell` (the "one text-cell formatter") behind every identifier cell: copies the raw value, swallows its click so a row's open-detail never fires. `CopyableNumberCell` now wraps it for «№…» ids; SKU / payment# / debt# / refund# / product info-rows use it directly. Link-styled partner-reference cells left as-is (keep the row-opens-source affordance).
- **`polish(typography)` — XC-17.** Transfer detail: inverted per-line quantity weight dropped (700→normal, product name is the bold element) and total-row quantity 800→700. Product image filename `text.disabled`→`text.secondary` + weight 600. Event-date cells across partner tabs (ink) and transactions/adjustments/transfers lists (gray700) converged onto the single `numericSx + text.secondary` idiom.
- **`polish(tables)` — XC-9 column order.** №/id-first, money-last across the flagged tables: partner transactions number-first (header+body+CSV in lockstep), money last on partner payments / payroll / wallet-transfers, salary before actions on employees, orders money rightmost-among-non-chips (chips stay trailing, consistent with the sales feed), product stock table regroups «Ед.» next to the warehouse.
- **`polish(tables)` — XC-10 table chrome.** Transfer line-items table wrapped in an overflow-hidden bordered container so its border-radius actually clips (was a no-op on the collapsed-border table). Product-detail transactions tab: bespoke «Все транзакции →» footer link → shared `TablePager` (paginates like its sibling tabs; drops the see-all deep-link + the dead i18n key).

### Notes
- **XC-1 (entity typeahead):** warehouse + wallet filters stay compact pills (small sets — owner ruling), and the stock category filter stays a compact dropdown too. The Products-header category typeahead remains the one typeahead. Closed.
- **XC-17 author cells:** left as-is — they already follow a coherent list-muted / detail-accented convention.
- **XC-10 items 4–6** (payments page-size, payroll amount header, sales/supplies alignment): already unified onto the shared `DataTable`; no change needed.
- A pre-existing `same key` console warning on `/products` is unrelated (this change adds no keys) and is tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard support for SKUs, transaction numbers, document references, barcodes, and other identifiers across tables and detail views.
  * Added pagination to product transaction history.
  * Added compact search field styling for selected detail views.

* **Improvements**
  * Reordered table columns for clearer presentation of payment, transaction, inventory, payroll, and transfer data.
  * Improved secondary text styling and responsive search field layout throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->