### PR TITLE
Adjustments: read-only detail modal replaces the expand row (XC-16 + C4)

### DIFF
--- a/src/components/stockAdjustment/Detail/StockAdjustmentDetailModal.tsx
+++ b/src/components/stockAdjustment/Detail/StockAdjustmentDetailModal.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import ProductLink from "components/product/Links/ProductLink";
+import GhostButton from "components/shared/Buttons/GhostButton";
+import FormDialogHeader from "components/shared/Dialog/Form/FormDialogHeader";
+import { CopyableCell } from "components/shared/Table/CopyableCell";
+import DirectionChip from "components/stockAdjustment/DirectionChip";
+import WarehouseLink from "components/warehouse/Links/WarehouseLink";
+import { StockAdjustment } from "models/stockAdjustment";
+import { designTokens, numericSx } from "theme";
+import { formatDateTime } from "utils/dateUtils";
+import { formatQuantity } from "utils/formatCurrency";
+import { MEASUREMENT_SHORT } from "utils/productUtils";
+
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
+import { Avatar, Box, Dialog, DialogActions, DialogContent, Typography } from "@mui/material";
+
+interface StockAdjustmentDetailModalProps {
+	adjustment: StockAdjustment | null;
+	onClose: () => void;
+}
+
+/** One labelled audited field (mirrors the former expand-panel field). */
+const Field: React.FC<{ label: string; children: React.ReactNode; mono?: boolean }> = ({
+	label,
+	children,
+	mono,
+}) => (
+	<Box>
+		<Typography sx={{ fontSize: 11.5, color: "text.secondary", mb: "5px" }}>{label}</Typography>
+		<Typography
+			component="div"
+			sx={{ fontSize: 13.5, color: "text.primary", fontWeight: 500, ...(mono ? numericSx : null) }}
+		>
+			{children}
+		</Typography>
+	</Box>
+);
+
+/**
+ * Read-only stock-adjustment detail (rule 23 — immutable, no edit / delete):
+ * a product · direction · signed-quantity summary, the audited fields, and the
+ * note. Opened from a row click on the adjustments table (replaces the former
+ * expand-row panel). Product + warehouse cells deep-link.
+ */
+export const StockAdjustmentDetailModal: React.FC<StockAdjustmentDetailModalProps> = ({
+	adjustment,
+	onClose,
+}) => {
+	const { t } = useTranslation();
+
+	if (!adjustment) {
+		return null;
+	}
+
+	const unit = MEASUREMENT_SHORT[adjustment.measurement];
+	const isDown = adjustment.direction === "Decrease";
+
+	return (
+		<Dialog
+			open
+			onClose={onClose}
+			disableRestoreFocus
+			slotProps={{ paper: { sx: { width: 560, maxWidth: "94%", borderRadius: "12px" } } }}
+		>
+			<FormDialogHeader
+				title={t("adjustment.detail.title")}
+				subtitle={`${formatDateTime(adjustment.date)} · ${adjustment.createdBy}`}
+				disabled={false}
+				onClose={onClose}
+			/>
+
+			<DialogContent dividers sx={{ pt: 2 }}>
+				{/* product · direction · signed quantity */}
+				<Box
+					sx={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+						gap: "12px",
+						flexWrap: "wrap",
+						p: "16px 18px",
+						mb: "18px",
+						bgcolor: designTokens.gray25,
+						border: "1px solid",
+						borderColor: "divider",
+						borderRadius: "8px",
+					}}
+				>
+					<Box sx={{ minWidth: 0 }}>
+						<Typography sx={{ fontSize: 11.5, color: "text.secondary", mb: "4px" }}>
+							{t("adjustment.table.product")}
+						</Typography>
+						<Typography component="div" sx={{ fontSize: 15, fontWeight: 600 }}>
+							<ProductLink id={adjustment.productId} name={adjustment.productName} />
+						</Typography>
+					</Box>
+					<Box sx={{ display: "flex", alignItems: "center", gap: "12px" }}>
+						<DirectionChip direction={adjustment.direction} />
+						<Box
+							component="span"
+							sx={{
+								...numericSx,
+								fontSize: 18,
+								fontWeight: 700,
+								color: isDown ? "error.main" : "success.main",
+							}}
+						>
+							{isDown ? "−" : "+"}
+							{formatQuantity(adjustment.quantity)}{" "}
+							<Box component="span" sx={{ fontSize: 13, color: "text.disabled", fontWeight: 600 }}>
+								{unit}
+							</Box>
+						</Box>
+					</Box>
+				</Box>
+
+				{/* audited fields */}
+				<Box
+					sx={{
+						display: "grid",
+						gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+						gap: "18px 28px",
+					}}
+				>
+					<Field label={t("adjustment.table.warehouse")}>
+						<WarehouseLink id={adjustment.warehouseId} name={adjustment.warehouseName} />
+					</Field>
+					<Field label={t("adjustment.table.sku")} mono>
+						<CopyableCell value={adjustment.sku}>{adjustment.sku}</CopyableCell>
+					</Field>
+					<Field label={t("adjustment.table.category")}>{adjustment.categoryName ?? "—"}</Field>
+					<Field label={t("adjustment.table.reason")}>
+						{t(`adjustment.reason.${adjustment.reason}`)}
+					</Field>
+					<Field label={t("adjustment.detail.balanceAfter")} mono>
+						{formatQuantity(adjustment.balanceAfter)} {unit}
+					</Field>
+					<Field label={t("adjustment.detail.createdBy")}>
+						<Box sx={{ display: "inline-flex", alignItems: "center", gap: "7px" }}>
+							<Avatar
+								sx={{
+									width: 22,
+									height: 22,
+									fontSize: 11,
+									fontWeight: 700,
+									bgcolor: "primary.light",
+									color: "primary.main",
+								}}
+							>
+								{adjustment.createdBy.trim().charAt(0)}
+							</Avatar>
+							<Box component="span" sx={{ color: "primary.main", fontWeight: 600 }}>
+								{adjustment.createdBy}
+							</Box>
+						</Box>
+					</Field>
+				</Box>
+
+				{/* note */}
+				<Box
+					sx={{
+						mt: "18px",
+						display: "flex",
+						alignItems: "flex-start",
+						gap: "8px",
+						p: "11px 14px",
+						bgcolor: "background.paper",
+						border: "1px solid",
+						borderColor: "divider",
+						borderRadius: "8px",
+						fontSize: 13,
+						color: designTokens.gray700,
+						lineHeight: 1.55,
+					}}
+				>
+					<ReceiptLongOutlinedIcon sx={{ fontSize: 15, color: "text.disabled", mt: "1px" }} />
+					{adjustment.note ?? (
+						<Box component="span" sx={{ color: "text.disabled" }}>
+							{t("adjustment.detail.noNote")}
+						</Box>
+					)}
+				</Box>
+
+				{/* immutability hint (rule 23) */}
+				<Box
+					sx={{
+						display: "flex",
+						gap: "10px",
+						alignItems: "flex-start",
+						mt: "16px",
+						p: "11px 13px",
+						bgcolor: "primary.light",
+						border: "1px solid",
+						borderColor: designTokens.primaryLine,
+						borderRadius: "8px",
+					}}
+				>
+					<InfoOutlinedIcon
+						sx={{ fontSize: 16, color: "primary.main", mt: "1px", flex: "0 0 auto" }}
+					/>
+					<Typography sx={{ fontSize: 12.5, color: "primary.dark", lineHeight: 1.55 }}>
+						{t("adjustment.detail.immutableHint")}
+					</Typography>
+				</Box>
+			</DialogContent>
+
+			<DialogActions
+				sx={{
+					px: "24px",
+					py: "14px",
+					borderTop: "1px solid",
+					borderColor: "divider",
+					bgcolor: designTokens.gray25,
+				}}
+			>
+				<GhostButton onClick={onClose}>{t("close")}</GhostButton>
+			</DialogActions>
+		</Dialog>
+	);
+};
+
+export default StockAdjustmentDetailModal;

--- a/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
+++ b/src/components/stockAdjustment/Table/StockAdjustmentsTable.tsx
@@ -1,11 +1,8 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ProductLink from "components/product/Links/ProductLink";
-import { CopyableCell } from "components/shared/Table/CopyableCell";
-import {
-	Column,
-	ExpandableDataTable,
-} from "components/shared/Table/ExpandableDataTable/ExpandableDataTable";
+import { Column, DataTable } from "components/shared/Table/DataTable/DataTable";
+import StockAdjustmentDetailModal from "components/stockAdjustment/Detail/StockAdjustmentDetailModal";
 import DirectionChip from "components/stockAdjustment/DirectionChip";
 import WarehouseLink from "components/warehouse/Links/WarehouseLink";
 import { Loadable } from "helpers/Loading";
@@ -16,10 +13,9 @@ import { formatQuantity } from "utils/formatCurrency";
 import { MEASUREMENT_SHORT } from "utils/productUtils";
 
 import AddIcon from "@mui/icons-material/Add";
-import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
 import ScaleOutlinedIcon from "@mui/icons-material/ScaleOutlined";
 import WarehouseOutlinedIcon from "@mui/icons-material/WarehouseOutlined";
-import { Avatar, Box, Button, CircularProgress, Paper, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Paper, Typography } from "@mui/material";
 
 interface StockAdjustmentsTableProps {
 	rows: Loadable<StockAdjustment[]>;
@@ -28,22 +24,6 @@ interface StockAdjustmentsTableProps {
 	hasAny: boolean;
 	onCreate: () => void;
 }
-
-const ExpandField: React.FC<{ label: string; children: React.ReactNode; mono?: boolean }> = ({
-	label,
-	children,
-	mono,
-}) => (
-	<Box>
-		<Typography sx={{ fontSize: 11.5, color: "text.secondary", mb: "5px" }}>{label}</Typography>
-		<Typography
-			component="div"
-			sx={{ fontSize: 13.5, color: "text.primary", fontWeight: 500, ...(mono ? numericSx : null) }}
-		>
-			{children}
-		</Typography>
-	</Box>
-);
 
 const EmptyState: React.FC<{ isFiltering: boolean; hasAny: boolean; onCreate: () => void }> = ({
 	isFiltering,
@@ -90,96 +70,10 @@ const EmptyState: React.FC<{ isFiltering: boolean; hasAny: boolean; onCreate: ()
 	);
 };
 
-/** The expand-row detail panel: the audited fields the row doesn't surface (rule 23). */
-const AdjustmentDetail: React.FC<{ adjustment: StockAdjustment }> = ({ adjustment }) => {
-	const { t } = useTranslation();
-	const unit = MEASUREMENT_SHORT[adjustment.measurement];
-
-	return (
-		<Box sx={{ p: "4px 6px 10px" }}>
-			<Box
-				sx={{
-					p: "16px 18px",
-					borderLeft: "2px solid",
-					borderLeftColor: "primary.main",
-					bgcolor: "background.default",
-					borderRadius: "0 8px 8px 0",
-				}}
-			>
-				<Box
-					sx={{
-						display: "grid",
-						gridTemplateColumns: { xs: "1fr", sm: "repeat(3, minmax(0, 1fr))" },
-						gap: "18px 28px",
-					}}
-				>
-					<ExpandField label={t("adjustment.table.sku")} mono>
-						<CopyableCell value={adjustment.sku}>{adjustment.sku}</CopyableCell>
-					</ExpandField>
-					<ExpandField label={t("adjustment.table.category")}>
-						{adjustment.categoryName ?? "—"}
-					</ExpandField>
-					<ExpandField label={t("adjustment.detail.dateTime")} mono>
-						{formatDateTime(adjustment.date)}
-					</ExpandField>
-					<ExpandField label={t("adjustment.detail.balanceAfter")} mono>
-						{formatQuantity(adjustment.balanceAfter)} {unit}
-					</ExpandField>
-					<ExpandField label={t("adjustment.table.reason")}>
-						{t(`adjustment.reason.${adjustment.reason}`)}
-					</ExpandField>
-					<ExpandField label={t("adjustment.detail.createdBy")}>
-						<Box sx={{ display: "inline-flex", alignItems: "center", gap: "7px" }}>
-							<Avatar
-								sx={{
-									width: 22,
-									height: 22,
-									fontSize: 11,
-									fontWeight: 700,
-									bgcolor: "primary.light",
-									color: "primary.main",
-								}}
-							>
-								{adjustment.createdBy.trim().charAt(0)}
-							</Avatar>
-							<Box component="span" sx={{ color: "primary.main", fontWeight: 600 }}>
-								{adjustment.createdBy}
-							</Box>
-						</Box>
-					</ExpandField>
-					<Box
-						sx={{
-							gridColumn: "1 / -1",
-							display: "flex",
-							alignItems: "flex-start",
-							gap: "8px",
-							p: "11px 14px",
-							bgcolor: "background.paper",
-							border: "1px solid",
-							borderColor: "divider",
-							borderRadius: "8px",
-							fontSize: 13,
-							color: designTokens.gray700,
-							lineHeight: 1.55,
-						}}
-					>
-						<ReceiptLongOutlinedIcon sx={{ fontSize: 15, color: "text.disabled", mt: "1px" }} />
-						{adjustment.note ?? (
-							<Box component="span" sx={{ color: "text.disabled" }}>
-								{t("adjustment.detail.noNote")}
-							</Box>
-						)}
-					</Box>
-				</Box>
-			</Box>
-		</Box>
-	);
-};
-
 /**
  * Immutable stock-adjustment history (rule 23 — no edit / delete): the shared
- * ExpandableDataTable (warm bands, sort, 10/25/50 pagination) with a per-row
- * expand panel carrying the audited detail. Product + warehouse cells deep-link
+ * DataTable (warm bands, sort, 10/25/50 pagination); a row click opens the
+ * read-only audited detail in a modal. Product + warehouse cells deep-link
  * (ADJ-2); direction is a chip, the signed quantity keeps its ledger +/− colour.
  */
 export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
@@ -189,6 +83,7 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 	onCreate,
 }) => {
 	const { t } = useTranslation();
+	const [selected, setSelected] = useState<StockAdjustment | null>(null);
 
 	const columns = useMemo<Column<StockAdjustment>[]>(
 		() => [
@@ -210,7 +105,7 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 				headerName: t("adjustment.table.warehouse"),
 				sortValue: (a) => a.warehouseName,
 				renderCell: (a) => (
-					// stopPropagation so the link navigates without toggling the row's expander.
+					// stopPropagation so the link navigates without opening the detail modal.
 					<Box
 						onClick={(e) => e.stopPropagation()}
 						sx={{ display: "inline-flex", alignItems: "center", gap: "7px", minWidth: 0 }}
@@ -253,7 +148,10 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 							}}
 						>
 							{isDown ? "−" : "+"}
-							{formatQuantity(a.quantity)} {MEASUREMENT_SHORT[a.measurement]}
+							{formatQuantity(a.quantity)}{" "}
+							<Box component="span" sx={{ color: "text.disabled", fontSize: 12 }}>
+								{MEASUREMENT_SHORT[a.measurement]}
+							</Box>
 						</Box>
 					);
 				},
@@ -302,15 +200,17 @@ export const StockAdjustmentsTable: React.FC<StockAdjustmentsTableProps> = ({
 	}
 
 	return (
-		<ExpandableDataTable<StockAdjustment>
-			rows={rows}
-			columns={columns}
-			pagination
-			rowsPerPageOptions={[10, 25, 50]}
-			defaultSort={{ key: "date", order: "desc" }}
-			renderExpanded={(adjustment) => <AdjustmentDetail adjustment={adjustment} />}
-			expandOnRowClick
-		/>
+		<>
+			<DataTable<StockAdjustment>
+				rows={rows}
+				columns={columns}
+				pagination
+				rowsPerPageOptions={[10, 25, 50]}
+				defaultSort={{ key: "date", order: "desc" }}
+				onRowClick={setSelected}
+			/>
+			<StockAdjustmentDetailModal adjustment={selected} onClose={() => setSelected(null)} />
+		</>
 	);
 };
 

--- a/src/i18n/ru/stockAdjustment.json
+++ b/src/i18n/ru/stockAdjustment.json
@@ -38,10 +38,12 @@
   "adjustment.table.category": "Категория",
   "adjustment.table.note": "Примечание",
 
+  "adjustment.detail.title": "Корректировка запаса",
   "adjustment.detail.dateTime": "Дата и время",
   "adjustment.detail.balanceAfter": "Остаток после операции",
   "adjustment.detail.createdBy": "Провёл",
   "adjustment.detail.noNote": "Без примечания",
+  "adjustment.detail.immutableHint": "Корректировки нельзя редактировать или удалять — они часть аудируемой истории склада.",
 
   "adjustment.empty.title": "Пока нет корректировок",
   "adjustment.empty.body": "Корректировки фиксируют изменения остатка без продаж и поставок — порча, недостача, пересчёт, находка. Создайте первую запись.",


### PR DESCRIPTION
Stacked on #93 (needs its adjustments-table state). Retarget to `redesign/issue-fixes` once #93 merges.

Stock adjustments are immutable (rule 23 — no edit/delete), so the table drops the per-row expand panel in favour of a read-only detail **modal**:

- `StockAdjustmentsTable` moves off `ExpandableDataTable` onto the shared `DataTable` with an `onRowClick` that opens the new **`StockAdjustmentDetailModal`** — a product · direction · signed-quantity summary, the audited fields (warehouse, SKU click-to-copy, category, reason, balance-after, author), the note, and an immutability hint. Mirrors the read-only `TransferDetailModal` (header + fields + `GhostButton` close). **No edit/delete affordances.**
- **Templates keeps its expandable rows** (only the adjustments table changed).
- Folds **C4**: the «ед.» unit in the quantity cell is muted to `text.disabled`, matching the `PositionsCard` idiom.

**Verified on :3000:** rows no longer expand (no chevron); a row click opens the modal with all audited fields; SKU copyable; immutability hint shown; only a Close button; unit muted.