### PR TITLE
Shared TableToolbar; consolidate the debts search/filters/export (XC-15 / DEC-D3)

### DIFF
--- a/src/components/debt/DebtFilters.tsx
+++ b/src/components/debt/DebtFilters.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { SearchInput } from "components/shared/SearchInput/SearchInput";
 import { SegmentedControl } from "components/shared/SegmentedControl/SegmentedControl";
 import { DebtAgeBucket, DebtDirectionFilter, DebtTab } from "stores/DebtStore";
 import { designTokens } from "theme";
@@ -14,11 +13,9 @@ import { Box, ButtonBase, ListItemText, Menu, MenuItem } from "@mui/material";
 
 interface DebtFiltersProps {
 	tab: DebtTab;
-	searchTerm: string;
 	ageBucket: DebtAgeBucket;
 	directionFilter: DebtDirectionFilter;
 	onlyOverdue: boolean;
-	onSearch: (v: string) => void;
 	onAgeChange: (v: DebtAgeBucket) => void;
 	onDirectionChange: (v: DebtDirectionFilter) => void;
 	onClearOverdue: () => void;
@@ -101,11 +98,9 @@ function Dropdown<T extends string>({
  */
 export const DebtFilters: React.FC<DebtFiltersProps> = ({
 	tab,
-	searchTerm,
 	ageBucket,
 	directionFilter,
 	onlyOverdue,
-	onSearch,
 	onAgeChange,
 	onDirectionChange,
 	onClearOverdue,
@@ -121,13 +116,7 @@ export const DebtFilters: React.FC<DebtFiltersProps> = ({
 	];
 
 	return (
-		<Box sx={{ display: "flex", alignItems: "center", gap: "10px", mb: "14px", flexWrap: "wrap" }}>
-			<SearchInput
-				value={searchTerm}
-				onChange={onSearch}
-				placeholder={t("debt.searchPlaceholder")}
-			/>
-
+		<>
 			{tab === "transactions" && (
 				<SegmentedControl
 					value={directionFilter}
@@ -171,7 +160,7 @@ export const DebtFilters: React.FC<DebtFiltersProps> = ({
 					<CloseIcon sx={{ fontSize: 14 }} />
 				</ButtonBase>
 			)}
-		</Box>
+		</>
 	);
 };
 

--- a/src/components/shared/Table/TableToolbar.tsx
+++ b/src/components/shared/Table/TableToolbar.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { SearchInput } from "components/shared/SearchInput/SearchInput";
+
+import { Box, SxProps, Theme } from "@mui/material";
+
+export interface TableToolbarProps {
+	/** Leftmost search box (optional). `dense` narrows it for in-card bands. */
+	search?: {
+		value: string;
+		onChange: (value: string) => void;
+		placeholder: string;
+		dense?: boolean;
+	};
+	/** Filter controls (segmented, dropdowns) rendered after the search. */
+	filters?: React.ReactNode;
+	/** Right-aligned actions (export, …), pushed to the far end by a spacer. */
+	actions?: React.ReactNode;
+	sx?: SxProps<Theme>;
+}
+
+/**
+ * Shared table toolbar band (XC-15): one flex row carrying the search box, the
+ * filter controls and right-aligned actions — the single home for a table's
+ * search / filters / export, so they sit with the table instead of scattered
+ * across the page header and separate filter rows. Wraps on narrow widths.
+ */
+export const TableToolbar: React.FC<TableToolbarProps> = ({ search, filters, actions, sx }) => (
+	<Box
+		sx={{
+			display: "flex",
+			alignItems: "center",
+			gap: "10px",
+			flexWrap: "wrap",
+			mb: "14px",
+			...sx,
+		}}
+	>
+		{search && (
+			<SearchInput
+				value={search.value}
+				onChange={search.onChange}
+				placeholder={search.placeholder}
+				dense={search.dense}
+			/>
+		)}
+		{filters}
+		{actions && (
+			<>
+				<Box sx={{ flexGrow: 1 }} />
+				{actions}
+			</>
+		)}
+	</Box>
+);
+
+export default TableToolbar;

--- a/src/pages/DebtPage.tsx
+++ b/src/pages/DebtPage.tsx
@@ -7,6 +7,7 @@ import { PartnerDebtTable, TransactionDebtTable } from "components/debt/DebtTabl
 import DebtTabs from "components/debt/DebtTabs";
 import GhostButton from "components/shared/Buttons/GhostButton";
 import PageHeader from "components/shared/PageHeader/PageHeader";
+import TableToolbar from "components/shared/Table/TableToolbar";
 import { observer } from "mobx-react-lite";
 import { Debt } from "models/debt";
 import { partnerDebtPath, saleDetailPath, supplyDetailPath } from "routing/paths";
@@ -67,17 +68,7 @@ const DebtPage: React.FC = observer(() => {
 
 	return (
 		<Box>
-			<PageHeader
-				title={t("debt.title")}
-				actions={
-					<GhostButton
-						icon={<FileDownloadOutlinedIcon sx={{ fontSize: "17px !important" }} />}
-						onClick={handleExport}
-					>
-						{t("debt.exportCsv")}
-					</GhostButton>
-				}
-			/>
+			<PageHeader title={t("debt.title")} />
 
 			{loading ? (
 				<Box sx={{ display: "flex", justifyContent: "center", py: 10 }}>
@@ -94,16 +85,31 @@ const DebtPage: React.FC = observer(() => {
 						onChange={debtStore.setTab}
 					/>
 
-					<DebtFilters
-						tab={debtStore.tab}
-						searchTerm={debtStore.searchTerm}
-						ageBucket={debtStore.ageBucket}
-						directionFilter={debtStore.directionFilter}
-						onlyOverdue={debtStore.onlyOverdue}
-						onSearch={debtStore.setSearch}
-						onAgeChange={debtStore.setAgeBucket}
-						onDirectionChange={debtStore.setDirectionFilter}
-						onClearOverdue={() => debtStore.setOnlyOverdue(false)}
+					<TableToolbar
+						search={{
+							value: debtStore.searchTerm,
+							onChange: debtStore.setSearch,
+							placeholder: t("debt.searchPlaceholder"),
+						}}
+						filters={
+							<DebtFilters
+								tab={debtStore.tab}
+								ageBucket={debtStore.ageBucket}
+								directionFilter={debtStore.directionFilter}
+								onlyOverdue={debtStore.onlyOverdue}
+								onAgeChange={debtStore.setAgeBucket}
+								onDirectionChange={debtStore.setDirectionFilter}
+								onClearOverdue={() => debtStore.setOnlyOverdue(false)}
+							/>
+						}
+						actions={
+							<GhostButton
+								icon={<FileDownloadOutlinedIcon sx={{ fontSize: "17px !important" }} />}
+								onClick={handleExport}
+							>
+								{t("debt.exportCsv")}
+							</GhostButton>
+						}
 					/>
 
 					{debtStore.tab === "partners" ? (


### PR DESCRIPTION
Stacked on #93 (the debts files were touched by C6/C7). Retarget to `redesign/issue-fixes` once #93 merges.

Per your DEC-D3 ruling ("build a shared TableToolbar"):

- New **`TableToolbar`** (`components/shared/Table`) — a single flex band with a `search` slot, a `filters` slot, and a right-aligned `actions` slot (wraps on narrow widths). The one home for a table's search / filters / export.
- **Debts page adopts it**: search, the debt filters (direction segmented on the transactions tab, age dropdown, overdue chip) and the **Export CSV** button — previously split between a separate filter row and the page-header action — now share one band above the table. `DebtFilters` becomes the filter-controls fragment (search moved into the toolbar); the page header is title-only.

**Verified on :3000:** both tabs render the consolidated band — partners: search + age + export; transactions: search + direction segmented + age + export — all in one row; export preserved (exports transaction rows, as before).

Note: `TableToolbar` is intentionally reusable; the partner-detail `DetailTableCard` band and list-page headers are candidates to migrate onto it in a later pass (kept out of scope here to keep the diff focused on the debts adoption).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable toolbar for table search, filters, and actions.
  * Debt search and CSV export are now presented together in a dedicated toolbar.
* **Improvements**
  * Simplified the debt page header to focus on the page title.
  * Preserved existing age, direction, and overdue filters while streamlining their layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->