### PR TITLE
Product measurement cleanup + partner form polish

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,105 @@
+# QA testing docs — Claude-driven manual testing
+
+Oracle-based manual test documentation, written to be executed by a Claude session driving the app in a real browser against the real backend. The goal is catching bugs — not blind smoke-verification: every case states exact expected outcomes (strings, formats, numbers) with canon citations, and the docs encode both kinds of traps (designed behavior that looks broken, and broken behavior that looks fine).
+
+## Doc map
+
+| File                                     | Purpose                                                                                      |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [environment.md](environment.md)         | Session setup: ports, backend, QA org, login handshake, permanence policy, tooling, hygiene  |
+| [shared-checklist.md](shared-checklist.md) | Cross-cutting assertions applied to every screen; forbidden-affordance scan; traps table    |
+| [fixtures.md](fixtures.md)               | QA org fixture registry + run-scoped entity naming                                           |
+| [smoke.md](smoke.md)                     | T1 smoke suite — whole-app render/navigation pass, read-mostly                               |
+| `modules/<module>.md`                    | Per-module deep test cases (happy path, edge, negative, reconciliation)                      |
+
+**Loading set for a QA run:** this README → [environment.md](environment.md) → [shared-checklist.md](shared-checklist.md) → [fixtures.md](fixtures.md) → the target module doc(s) → [../frontend-gaps.md](../frontend-gaps.md) (open F-items so known issues aren't reported as new). Canon (`../../../Ombor.Docs/business-rules.md`, `ui-patterns.md`, `decision-log.md`) is consulted on citation, not read whole.
+
+## Run tiers
+
+| Tier | What                                                          | When                                | Writes                   |
+| ---- | ------------------------------------------------------------- | ----------------------------------- | ------------------------ |
+| T1   | [smoke.md](smoke.md) + hygiene sweep                          | quick confidence check, post-merge  | none                     |
+| T2   | one module doc, all cases                                     | after changing that module          | run-scoped, permanent    |
+| T3   | smoke + all authored module docs                              | pre-release                         | run-scoped, permanent    |
+
+T3 is several hours; split it across sessions by module group if needed and merge the reports.
+
+## Test-case format
+
+Cases live in `modules/<module>.md` with stable IDs `T-<MOD>-NN` (never renumbered; gaps allowed). Tags: `[happy]` `[edge]` `[negative]` `[reconcile]`; cases creating permanent events additionally carry `✍`. Structure per case:
+
+```markdown
+### T-PAY-12 · Advance offered only at zero outstanding debt [edge] ✍
+Pre: run-scoped partner with one unpaid sale (from T-PAY-10).
+Steps: terse, imperative, numbered.
+Expect: exact outcomes, each citing canon — (R40, #6).
+Known: F-9 — if the allocation block crashes, report KNOWN, not new.
+```
+
+- **Preconditions** name fixtures ([fixtures.md](fixtures.md)) or earlier cases whose data they reuse — deep passes run a module's cases in order.
+- **Expect** lines cite `R n` / `#n` / `DR-n` so ambiguity is resolvable against canon; docs cite, they don't restate.
+- **Known** annotations map expected failures to open F-items. If a `Known` case *passes*, report "F-x may be fixed — verify and update frontend-gaps.md".
+- Module docs also carry: a surfaces list (routes/modals), module-specific traps, and reconciliation checks (cross-screen number consistency — the highest-value tier, since the product's differentiator is a dispute-grade ledger).
+
+## Session runbook
+
+1. Load the docs per **Loading set** above. Note the current branch and whether the working tree is dirty (report it — behavior may be ahead of docs).
+2. Environment + login handshake per [environment.md](environment.md). Verify the QA org before any write.
+3. Execute the tier's cases in doc order. For each: PASS / FAIL / KNOWN / BLOCKED / SKIP. On FAIL, gather evidence immediately (page text, network entry, screenshot if visual) before moving on — state is often unrecoverable later.
+4. Track every run-scoped entity created; archive archivable ones at the end.
+5. Deliver the report (below). Never mark the run complete on build/console silence alone — results come from exercised behavior.
+
+## Report format
+
+```markdown
+## QA run — <tier> — <date>
+Env: branch/commit · backend up · QA org verified · working tree clean/dirty
+| ID | Result | Note |
+…one row per executed case…
+
+### New defects
+Per defect: repro steps · expected (with citation) vs actual · evidence · severity (Blocker/Important/Cosmetic).
+
+### Known-issue observations
+F-items confirmed still present; expected-fails that now pass (fix candidates).
+
+### Data created
+Run-scoped entities (name → archived?).
+```
+
+New confirmed FE↔backend gaps discovered by a run are recorded as F-items in [../frontend-gaps.md](../frontend-gaps.md) with contract evidence, per the existing convention.
+
+## Maintenance
+
+- **Test docs track behavior:** any change to a module's user-facing behavior updates its `modules/<module>.md` in the same change (same discipline as `repo-state.md`). New modules get a test doc when they ship.
+- Known-issue truth lives in [../frontend-gaps.md](../frontend-gaps.md) — test docs reference F-items, never duplicate their content.
+- Canon changes (rules/patterns) ripple: a session changing cited behavior re-checks the citing cases.
+
+## Module doc status
+
+| Module doc                      | ID prefix | Status                                  |
+| ------------------------------- | --------- | --------------------------------------- |
+| `modules/sales-supplies.md`     | T-POS     | ✅ Wave 1                                |
+| `modules/refunds.md`            | T-RFD     | ✅ Wave 1                                |
+| `modules/payments.md`           | T-PAY     | ✅ Wave 1                                |
+| `modules/debts.md`              | T-DBT     | ✅ Wave 1                                |
+| `modules/wallets.md`            | T-WAL     | ✅ Wave 1                                |
+| `modules/partners.md`           | T-PRT     | ✅ Wave 1                                |
+| `modules/warehouses.md`         | T-WHS     | Wave 2 (planned)                        |
+| `modules/stock-adjustments.md`  | T-ADJ     | Wave 2 (planned)                        |
+| `modules/transfers.md`          | T-TRF     | Wave 2 (planned)                        |
+| `modules/orders.md`             | T-ORD     | Wave 2 (planned)                        |
+| `modules/templates.md`          | T-TPL     | Wave 2 (planned)                        |
+| `modules/products.md`           | T-PRD     | Wave 2, light until rebuild (F1)        |
+| `modules/categories.md`         | T-CAT     | Wave 2, light until rebuild             |
+| `modules/employees-payroll.md`  | T-EMP     | Wave 3 (planned)                        |
+| `modules/settings.md`           | T-SET     | Wave 3 (planned)                        |
+| `modules/auth.md`               | T-AUTH    | Wave 3 (planned; registration/OTP flows are owner-executed) |
+| `modules/dashboard.md`          | T-DSH     | Wave 3 (planned; reconciliation-heavy)  |
+
+Excluded until built: Activity Log (U1 — smoke checks the placeholder), Акт сверки (U2), Reports (v2 — absence from nav is asserted in smoke).
+
+## One-time setup still pending
+
+1. **QA org registration + fixture seeding** — see [fixtures.md](fixtures.md) (owner registers; Claude seeds).
+2. **First live smoke run** to validate this harness end-to-end; expect doc fixes from it.

--- a/docs/testing/environment.md
+++ b/docs/testing/environment.md
@@ -1,0 +1,46 @@
+# QA environment & session setup
+
+How a Claude QA session gets a working, authenticated app and what it is allowed to do. Read once at the start of every QA session, before any other testing doc.
+
+## Stack under test
+
+- **Frontend:** Vite dev server on **`http://localhost:3000`** — start/reuse via the Browser pane (`preview_start {name: "ombor-web"}`, defined in `.claude/launch.json`). The port is mandatory: the backend CORS allowlist only accepts `:3000`; on any other port login fails in the browser as `net::ERR_FAILED` (not a 401). If the owner's own dev server occupies `:3000` outside the preview system, ask them to stop it — never kill it.
+- **Backend:** real Ombor.API at **`http://localhost:5062`** (`VITE_OMBOR_API_BASE_URL` in `.env.development`); mocks are off (`VITE_ENABLE_MOCKS=false`). If the backend is down the app shows the offline banner and blocks submits — ask the owner to start it. Never test against MSW mocks; `src/mocks/` is dead code.
+- **Quirk:** the dev server may bind IPv6-only. If `http://localhost:3000` refuses connections while the server is demonstrably running, use `http://[::1]:3000`.
+
+## QA organization (the test tenant)
+
+- All QA runs execute inside the dedicated **QA organization** — a separate tenant on the dev backend. Its books absorb permanent test data; the owner's real organizations must never be touched. Identity and fixtures: [fixtures.md](fixtures.md).
+- The owner's dev account `+998900000001` is **not** the QA org — never write test events under it.
+- If it is unclear which org the session is logged into (fixture entities from `fixtures.md` missing, unfamiliar data), **stop and ask** — do not write events into an unidentified org.
+
+## Login handshake
+
+1. `preview_start {name: "ombor-web"}` (reuses a running server).
+2. If the app lands on `/login`: ask the owner to log into the **QA org** in the preview browser and wait. Claude never types passwords (safety rule).
+3. Before any write test, verify identity: the sidebar/topbar shows the QA user, and at least one stable fixture from `fixtures.md` is present.
+
+## Data permanence policy
+
+- Transactions, payments, payroll, stock adjustments, and transfers are immutable (business-rules R1) — every write in a QA run stays in the QA org's books forever (DR-15: the dev DB is never wiped). There is no cleanup of events, by design.
+- Run-scoped entities created for numeric oracles follow the naming convention in [fixtures.md](fixtures.md) (`QA-<MMDD> …`) so the books stay interpretable months later.
+- Do not run money/stock events through stable fixture entities unless a case explicitly says so — fixture balances should drift as little as possible.
+- Archivable run-scoped entities (partners, products, wallets, warehouses) should be archived at the end of a run.
+
+## What a QA run is authorized to do
+
+- The owner's QA request authorizes: navigating the app, filling and submitting forms **inside the app under test** with test data, and creating test entities/events in the QA org.
+- Always out of scope: entering real personal data or any credentials; writing into a non-QA org; creating or deleting accounts; acting on any external site.
+
+## Tooling guidance (Browser pane)
+
+- Prefer `read_page` / `get_page_text` for content assertions, `read_network_requests` for API status/payload verification, `read_console_messages` for hygiene. **Screenshots are slow and may time out on this machine** — take them sparingly, mainly as evidence of a confirmed visual defect.
+- Verify server-computed figures (balances, WAC, totals, «Наши средства») against the API response via `read_network_requests` — never against hand-summed event lists (R12). For arithmetic oracles, the sum is computed from inputs the test itself created.
+- Negative cases assert the **surfaced** error (inline field error or toast per DR-24) *and* may confirm the HTTP status in the network log (expected statuses per case).
+- Interactions: `computer` (click/type) and `form_input`; confirm outcomes with `read_page`, not by assuming the click worked.
+
+## Hygiene assertions (every run, every tier)
+
+- Zero console errors across all exercised screens (new warnings: note in the report).
+- No unexpected 4xx/5xx responses — expected ones are named by negative test cases.
+- Zero requests to `*.sentry.io` / `*.posthog.com` — telemetry is production-only; any such request in dev is itself a defect.

--- a/docs/testing/fixtures.md
+++ b/docs/testing/fixtures.md
@@ -1,0 +1,40 @@
+# QA org fixtures
+
+The registry of stable entities in the QA organization, plus the naming rules for entities tests create at run time. Module test cases reference fixtures by the names below.
+
+## Status: NOT YET SEEDED
+
+The QA org does not exist yet. Setup sequence (one session, owner + Claude together):
+
+1. **Owner registers the QA org** on the dev backend via `/register` (account creation and OTP entry are owner-only actions) and logs into it in the preview browser.
+2. Claude seeds the stable fixture registry below through the UI, then replaces this section with the actual org identity and records any deviations in the tables.
+
+## Identity (fill at seeding)
+
+- Org name: _(fill)_ · QA user phone: _(fill)_ · Registered: _(date)_
+
+## Naming rules
+
+- **Stable fixtures** are prefixed «QA » and listed below. They exist permanently and are used for pickers, read paths, and non-numeric flows.
+- **Run-scoped entities** are named `QA-<MMDD> <name>` (e.g. «QA-0716 Партнёр А») and created fresh during a run wherever a case needs known starting numbers. Archive archivable ones at run end.
+
+## Stable fixture registry (target set)
+
+| Entity    | Name                                       | Configuration                                            | Purpose                                     |
+| --------- | ------------------------------------------ | -------------------------------------------------------- | ------------------------------------------- |
+| Warehouse | QA Склад А · QA Склад Б                    | plain                                                     | transfers, per-warehouse stock/WAC          |
+| Wallet    | QA Касса · QA Карта · QA Банк              | types Cash / Card / Bank, opening balance 1 000 000 each | payment sources, wallet transfers, overdraft |
+| Partner   | QA Клиент · QA Поставщик · QA Универсал    | types Customer / Supplier / Both, opening balance 0      | pickers, payment-direction derivation        |
+| Category  | QA Категория                               | —                                                         | product forms                                |
+| Product   | QA Товар Штучный                           | unit Piece, no packaging, supply 10 000 / sale 15 000    | POS lines, simple math                       |
+| Product   | QA Товар Упаковка                          | packaging size 12, supply 12 000 / sale 18 000           | package-unit math (R21)                      |
+| Product   | QA Товар Поставка                          | type Supply                                               | product-type filtering                       |
+| Employee  | QA Сотрудник                               | Active, salary 3 000 000                                  | payroll                                      |
+
+Registration also seeds 1 starter wallet, warehouse, category, and partner (R42) — ordinary entities. Leave them in place; they double as archive/delete-gating material.
+
+## Books discipline
+
+- Stable fixtures accumulate history as tests run. **Never assert an absolute balance or stock level on a stable fixture** — assert deltas (before/after within the run) or use run-scoped entities.
+- Numeric-oracle cases (WAC math, advances, settlement identities) **always** use run-scoped products/partners so arithmetic starts from a known zero state.
+- Keep fixture wallets' use to payment-source selection; wallet-balance oracles use run-scoped wallets.

--- a/docs/testing/modules/debts.md
+++ b/docs/testing/modules/debts.md
@@ -1,0 +1,126 @@
+# Debts — test cases (T-DBT)
+
+Read-only aggregate over `GET /api/debts` — no writes on this page; precondition events are created via POS, payments, and refund flows.
+Read with: [../README.md](../README.md) · [../shared-checklist.md](../shared-checklist.md) · [../fixtures.md](../fixtures.md) · [partners.md](partners.md) (POV trap) · [sales-supplies.md](sales-supplies.md) (POS) · [payments.md](payments.md) (payment modal) · [refunds.md](refunds.md) (refund modal).
+
+## Surfaces
+
+- `/debts` (sidebar «Долги»). Read-only: no create button, no `⋮` menus, no row actions — correct, not a gap.
+- `DebtSummaryCards` — 4 cards: «Нам должны» (green), «Мы должны» (red), «Просрочено» (orange), «Чистая позиция» (color by sign). First three clickable (hover arrow), net card is not. Each carries a «N транзакций» pill and a small «UZS» suffix.
+- `DebtTabs` — underline tabs «По партнёрам» / «По транзакциям» with count pills; right-aligned legend swatches «нам должны» (green) / «мы должны» (red).
+- Toolbar — search «Поиск по партнёру или номеру…» (matches partner name, company, document-number substring); «Срок:» dropdown («Все сроки / 0–7 дней / 8–30 дней / 31–60 дней / 60+ дней»); direction segmented «Все | Нам должны | Мы должны» (**transactions tab only** — absent on partners tab by design); clearable «Только просроченные» chip (appears only via the «Просрочено» card); «Скачать CSV».
+- Exits: partner-tab row → `/partners/:id?tab=transactions&status=open`; transaction-tab row → `/supplies/:id` for Supply/SupplyRefund, `/sales/:id` otherwise; partner name inside a row → partner detail (does not open the transaction).
+
+## Traps
+
+Module-specific designed-behavior-looks-like-bug items (shared-checklist §6 still applies):
+
+| Observation | Why it's correct |
+| --- | --- |
+| A debt green «Нам должны» here renders red/negative on that partner's detail page | /debts and Dashboard are owner-POV; partner detail is partner-POV signed — see partners.md before judging |
+| A row with «Возраст» 200 дн and no «просрочка» chip; «Просрочено» card stays 0 | blank `dueDate` = due on receipt, never overdue (contract `overdueDays` = 0 without due date). No UI collects a due date today — a QA run can never create an overdue debt |
+| Dashboard «Просрочено» ≠ /debts «Просрочено» card | deliberate: dashboard = receivables aged 31+ days; /debts = due-date overdue, both directions (contract; repo-state Dashboard) |
+| Cards don't move when searching/filtering/switching tabs | summary is a global snapshot over ALL open debts, never the filtered view |
+| Partner-tab «Тип» chip contradicts the partner's real type (a Customer shown as «Поставщик») | chip encodes the debt role: «Клиент» = they owe us, «Поставщик» = we owe them |
+| Red 70 000 sorts above green 60 000 in «Сумма долга» | column sorts by absolute exposure regardless of direction; direction is color-only, no ± signs (#4) |
+| Refund rows inside a "debts" list | unpaid SupplyRefund = receivable, unpaid SaleRefund = payable (business-rules Domain model) |
+| Direction segmented missing on «По партнёрам» | tab-scoped by design — partner rows are already direction-netted (repo-state Debts) |
+
+## Happy path
+
+Run in doc order — later cases consume earlier cases' data. `<MMDD>` = run date.
+
+### T-DBT-01 · Seed run debt set — cards move by exact gross deltas [happy] ✍
+Pre: QA org; stable fixtures «QA Склад А», «QA Касса», «QA Товар Штучный» (supply 10 000 / sale 15 000) per fixtures.md.
+Steps: 1. Open /debts; record all four card values + pill counts (baseline — never assert absolutes, fixtures.md). 2. Create partners «QA-<MMDD> Дебитор» (Клиент, opening 0) and «QA-<MMDD> Универсал» (Клиент + Поставщик, opening 0). 3. New Supply (sales-supplies.md): Универсал, QA Склад А, QA Товар Штучный ×10 @ 10 000 = 100 000, no payment; note its «№» (call it D1). 4. New Sale: Дебитор, QA Склад А, ×4 @ 15 000 = 60 000, no payment (D2). 5. New Sale: Универсал, QA Склад А, ×2 @ 15 000 = 30 000, no payment (D3). 6. Reload /debts.
+Expect: «Нам должны» +90 000, pill +2; «Мы должны» +100 000, pill +1; «Просрочено» ±0 (no due dates — Traps); «Чистая позиция» delta −10 000, value unsigned, color by net sign (#4); figures served, page only sums them (R12). Pill plurals correct: 1 «транзакция» / 2–4 «транзакции» / 5+ «транзакций».
+Known: F16 — plural words and the card «UZS» unit are hardcoded strings.
+
+### T-DBT-02 · Transaction row anatomy — fresh debt, age 0, direction colors [happy]
+Pre: T-DBT-01.
+Steps: 1. Tab «По транзакциям»; search «QA-<MMDD>».
+Expect: three rows. Each: «№N» via formatEntityId (DR-21) + copyable, timestamp «DD.MM.YYYY HH:MM»; «Возраст» = «0 дн», no «просрочка» chip; badges «Поставка» (D1) / «Продажа» (D2, D3); Сумма/Оплачено/Остаток = 100 000/0/100 000, 60 000/0/60 000, 30 000/0/30 000 — remaining = total − paid (contract DebtDto, R12); «Остаток» green on receivable rows, red on the payable row, no ± signs (#4); leading icon box differs by direction (green ↗ receivable vs orange truck payable).
+
+### T-DBT-03 · Partial payment updates paid/remaining and the receivable card [happy] ✍
+Pre: T-DBT-01; record «Нам должны» and «Чистая позиция».
+Steps: 1. Payments → «Оплата» from Дебитор, wallet «QA Касса», 25 000, allocated to D2 (payments.md owns the modal; single open item — auto-allocation hits D2). 2. Reload /debts; search «Дебитор».
+Expect: D2 row now 60 000 / 25 000 / 35 000 (remaining = total − paid); the row stays listed — partially-paid is still a debt (contract: unpaid/partially-paid set); «Нам должны» −25 000 with count unchanged; «Чистая позиция» delta −25 000.
+
+### T-DBT-04 · По партнёрам groups net per partner while cards stay gross [happy]
+Pre: T-DBT-01..03 (Универсал holds BOTH directions: receivable 30 000 + payable 100 000).
+Steps: 1. Tab «По партнёрам»; search «QA-<MMDD>». 2. Record the Универсал row amount AND the gross card values.
+Expect: «QA-<MMDD> Дебитор»: 1 транзакция, «Сумма долга» 35 000 green, «в сроке» under «Старейший долг». «QA-<MMDD> Универсал»: count 2, oldest = today, amount = |30 000 − 100 000| = 70 000 red (per-partner signed net; unsigned display, color = direction, #4); «Тип» chip renders the newest row's debt role — expected «Клиент» (D3 is newest). **Explicit compare:** the cards count this partner gross (its 30 000 inside «Нам должны», its 100 000 inside «Мы должны») while its row shows net 70 000 — internally consistent arithmetic, but record the observed pair in the report: the gross-cards-vs-net-rows presentation is a standing product-audit concern (not an F-item; report as observation with numbers, not a new defect).
+
+### T-DBT-05 · Clickable summary cards preset the transactions tab [happy]
+Pre: T-DBT-01+.
+Steps: 1. From the partners tab click «Нам должны». 2. Click «Мы должны». 3. Sort by any header manually, then click «Мы должны» again. 4. Click «Просрочено». 5. Clear the «Только просроченные» chip via its ×.
+Expect: 1→ jumps to «По транзакциям», segmented «Нам должны» active, receivable rows only, initial sort «Остаток» desc; 2→ segmented «Мы должны», payable rows only; 3→ re-click re-seeds the sort even after a manual re-sort (repo-state Debts decision — preset seeds via nonce); 4→ segmented resets to «Все», chip «Только просроченные» appears, only rows with an overdue chip remain (with run data only: filtered empty state «Ничего не найдено»), initial sort «Возраст» desc; 5→ chip gone, rows return. «Чистая позиция» is not clickable — no hover arrow, no action.
+
+### T-DBT-06 · Search and tab count pills track the filtered view [happy]
+Pre: T-DBT-01+.
+Steps: 1. Clear filters; note both tab pills. 2. Search «QA-<MMDD> Универсал». 3. Search D2's bare number (digits only). 4. Search «zzzнет».
+Expect: 2→ transactions pill = the run Универсал's open rows, partners pill = 1; 3→ the D2 row is present; any other rows shown must contain the searched digits as a substring of their «№» or partner name/company (search is substring over name, company, and number) — only a row matching neither is a FAIL; 4→ pills 0 and the module empty state «Ничего не найдено» + «Под выбранные фильтры не попала ни одна транзакция…» (module-specific card, not the shared «Нет записей»); cards unchanged throughout (Traps).
+
+### T-DBT-07 · Drill-downs: partner row, transaction row, partner cell [happy]
+Pre: T-DBT-01+.
+Steps: 1. Partners tab → click the Универсал row. 2. Back. 3. Transactions tab → click the D1 (supply) row. 4. Back. 5. Click the partner name inside D2's row.
+Expect: 1→ URL `/partners/<id>?tab=transactions&status=open`; partner detail opens on «Транзакции» with the status filter preset to open/outstanding items inside the table widget (#14; PartnerDetailPage deep-link); 2/4→ back returns to /debts (#20a); 3→ `/supplies/<D1 id>` detail (Supply and SupplyRefund route to /supplies, Sale/SaleRefund to /sales); 5→ navigates to the partner detail, not the transaction — the inner link suppresses the row click.
+
+### T-DBT-08 · CSV exports the current filtered transactions view [happy]
+Pre: T-DBT-01+.
+Steps: 1. Transactions tab; direction «Нам должны»; search «QA-<MMDD>». 2. «Скачать CSV». 3. Switch to «По партнёрам», export again.
+Expect: file `debts_<datestamp>.csv`; headers Документ/Дата/Тип/Партнёр/Сумма/Оплачено/Остаток/Возраст (дней); rows = exactly the visible filtered receivable run rows (#11 — filtered view); 3→ export still emits transaction-level rows (never partner groups) — current implementation; record as observation only if the owner flags it.
+
+## Edge & negative
+
+### T-DBT-30 · Age-bucket boundaries; a fresh debt lands in «0–7 дней» [edge]
+Pre: T-DBT-01+ (all run debts ageDays 0).
+Steps: 1. Transactions tab; search «QA-<MMDD>». 2. «Срок: 0–7 дней». 3. «Срок: 8–30 дней». 4. «Срок: Все сроки». 5. Partners tab with «0–7 дней» still set.
+Expect: 2→ every run row present (buckets partition on served ageDays: ≤7 / 8–30 / 31–60 / >60; contract: ageDays = days since transaction date); 3→ zero run rows, «Ничего не найдено»; 5→ the age filter also constrains partner groups (shared filter across tabs); dropdown shows active styling when non-default.
+
+### T-DBT-31 · Blank due date is never overdue, at any age [edge]
+Pre: any org data; run rows from T-DBT-01.
+Steps: 1. Transactions tab, «Все сроки», empty search. 2. Scan for rows with large «Возраст» and no chip. 3. Compare the «Просрочено» card against the set of rows carrying a red «просрочка N дн» chip.
+Expect: rows without a due date show only «N дн» — no chip regardless of age (contract: overdueDays = 0 when no due date; Traps); «Просрочено» card value = Σ «Остаток» over chip-carrying rows only, both directions counted; since no UI collects a due date, if zero chips exist anywhere the card must read 0 with «0 транзакций».
+
+### T-DBT-32 · Unpaid SupplyRefund appears as a receivable [edge] ✍
+Pre: T-DBT-01 (D1 open, 100 000); record cards.
+Steps: 1. Pay D1 in full: «Оплата» from Универсал, direction «Расход» (Both partner ⇒ direction user-set, R14), 100 000 allocated manually to D1 (payments.md). 2. Reload /debts — confirm the D1 row is gone. 3. On `/supplies/<D1>` create a refund: 3 × QA Товар Штучный @ 10 000, reason «QA возврат» (refunds.md; R7). 4. Reload /debts; search «Универсал».
+Expect: after 2: «Мы должны» −100 000, count −1 (fully paid transactions leave the read model — contract); after 4: new row, badge «Возврат поставки», remaining 30 000 **green receivable** — an unpaid SupplyRefund is money the supplier owes us (business-rules Domain model); «Нам должны» +30 000, +1; Универсал partner row: 2 транзакции, net 30 000 + 30 000 = 60 000 green; row click → `/supplies/<refund id>`.
+Known: the CSV «Тип» column renders this row as «Продажа» (direction-derived label, `DebtPage.tsx` export) while the table badge says «Возврат поставки» — pre-existing Cosmetic inconsistency, report as observation, not new.
+
+### T-DBT-33 · Unpaid SaleRefund appears as a payable; role chip flips [edge] ✍
+Pre: T-DBT-03 (D2 remaining 35 000); record cards.
+Steps: 1. Pay D2's remaining 35 000 in full («Оплата» from Дебитор, auto-allocates). 2. On `/sales/<D2>` refund 1 unit @ 15 000, reason «QA возврат». 3. Reload /debts; search «Дебитор».
+Expect: «Нам должны» −35 000 after step 1; after 2: one row, badge «Возврат», remaining 15 000 **red payable** — an unpaid SaleRefund is money we owe the customer (business-rules Domain model); «Мы должны» +15 000; partners tab: Дебитор row 15 000 red with «Тип» chip «Поставщик» although the partner's real type is Клиент — the debt-role chip (Traps), not a defect.
+
+### T-DBT-34 · Filters and tab switches never move the cards [edge]
+Pre: T-DBT-01+.
+Steps: 1. Record all four cards. 2. Apply search «Универсал» + «Срок: 60+» + direction «Мы должны»; toggle both tabs; clear everything.
+Expect: cards identical throughout — the summary is computed over the full served list, never the filtered view; the direction segmented exists only on «По транзакциям» and never affects partner groups (Traps); pills and table contents do change with filters (contrast T-DBT-06).
+
+## Reconciliation
+
+Run after the edge cases (their writes are in the books). Perform paired reads back-to-back with no writes in between.
+
+### T-DBT-60 · /debts cards ↔ dashboard receivable/payable KPIs [reconcile]
+Steps: 1. /debts: record «Нам должны» / «Мы должны» values + pill counts. 2. Open `/` (dashboard), any period.
+Expect: dashboard receivable KPI value = «Нам должны» card and payable KPI value = «Мы должны» card, exactly (contract: dashboard debt figures are a snapshot that reconciles with `GET /api/debts`; `period` drives only revenue/series). KPI counts expected to equal the pill counts (verify against contract partners-debts-dashboard.md if they diverge).
+
+### T-DBT-61 · Dashboard «Просрочено» = 31+-day receivable aging, NOT /debts overdue [reconcile]
+Steps: 1. /debts transactions tab: direction «Нам должны», «Срок: 31–60» → sum «Остаток»; repeat with «60+»; S = both sums. 2. Record the /debts «Просрочено» card C. 3. Dashboard: record the overdue KPI V.
+Expect: V = S (contract: dashboard Overdue = receivables aged 31+ days). Do **not** assert V = C — C is due-date overdue across both directions; V ≠ C is designed (Traps; repo-state Dashboard). V ≠ S is a real FAIL. With a young QA org S, C, V may all be 0 — equality then proves nothing; note it and pass on V = S.
+
+### T-DBT-62 · Dashboard aging panel ↔ /debts bucket sums [reconcile]
+Steps: for each bucket 0-7 / 8-30 / 31-60 / 60+: /debts direction «Нам должны» + matching «Срок» filter → sum «Остаток»; compare with the dashboard aging panel amount for that bucket.
+Expect: equal per bucket — panel buckets are receivable remaining and the /debts age predicates partition identically (contract DashboardAgingBucketDto + DebtDto.ageDays). Payable rows never enter the panel.
+
+### T-DBT-63 · Partner row ↔ partner detail balance card (POV flip) [reconcile]
+Pre: T-DBT-32/33 done. Equality below holds only because both run partners have opening 0 and no advances — in general partner balance ≠ open-debt sum (openings and advances enter the ledger, not /debts); never report that inequality on other partners.
+Steps: 1. /debts partners tab: record Универсал (expect 60 000 green) and Дебитор (expect 15 000 red). 2. Open each partner's detail page.
+Expect: Универсал balance card magnitude 60 000, Дебитор 15 000 (R12 — both served from the same books); the partner page renders **partner-POV** signed/colored — Универсал (owes us) shows red/negative there vs green on /debts; Дебитор (we owe) shows green there vs red on /debts. Opposite colors for the same fact are both correct (partners.md POV trap; repo-state Partners decision amending #4).
+
+### T-DBT-64 · Cross-tab identity: rows = groups = net card [reconcile]
+Steps: 1. Clear all filters. 2. Transactions tab: R = Σ «Остаток» over green rows, P = Σ over red rows (use the CSV from T-DBT-08 mechanics for large sets). 3. Partners tab: N = Σ signed row sums (green +, red −). 4. Cards.
+Expect: R = «Нам должны», P = «Мы должны», N = R − P = «Чистая позиция» (magnitude + color by sign); partners pill = distinct partners among the rows; transactions pill = row count. All three views aggregate one served list — any drift is a real defect (R12).
+Known: Σ of partner-row **magnitudes** ≠ R + P whenever a mixed-direction partner exists (rows net, cards gross — see T-DBT-04); that alone is the documented observation, not drift.

--- a/docs/testing/modules/partners.md
+++ b/docs/testing/modules/partners.md
@@ -1,0 +1,143 @@
+# Partners — test cases (T-PRT)
+
+Partner master data: list + summary strip, detail (balance, dispute-grade ledger, tabs), create/edit, archive/restore, reference-gated delete. Read with [../README.md](../README.md) · [../shared-checklist.md](../shared-checklist.md) · [../fixtures.md](../fixtures.md) · [../../frontend-gaps.md](../../frontend-gaps.md).
+
+## Surfaces
+
+- `/partners` — list: `PageHeader` («Партнёры», «Новый партнёр», «Экспорт CSV»), `PartnerSummaryStrip` (3 cards), search + type segmented («Все | Клиенты | Поставщики») + archive segmented «Активные | Архив», `PartnersTable`.
+- `/partners/:id` — detail: `DetailPageHeader` (name; type chip + company as titleExtra), sticky 372px right rail (balance hero + «Обороты» + «Контакты»), `DetailTabs` Журнал / Транзакции / Платежи with count pills. Deep-link params: `?tab=transactions|payments&status=open|paid|partial|unpaid`.
+- `PartnerFormModal` (create/edit — shared by list and detail) · `PartnerDialogs` (archive / restore / delete / cannot-delete confirms).
+- Entry points: sidebar «Партнёры»; `PartnerLink` from Debts, transaction/order rows and details.
+
+## Traps
+
+Module-specific designed-behavior; shared-checklist traps not repeated.
+
+| Observation | Why it's correct (or how to report) |
+| --- | --- |
+| **Balances on ALL partner surfaces are SIGNED, partner-POV**: «−50 000» red = partner owes us, «+50 000» green = we owe partner (list column, detail hero, ledger Сумма/Баланс после, form previews). Contradicts locked #4 (unsigned natural-language) and the shared forbidden-affordance «+/− on balances». | Deliberate display-only flip (repo-state Partners decision; served value stays company-POV, R12). Do NOT report signs/colors here as defects. DO note in the report: **#4 canon amendment still pending — confirm with owner.** |
+| Red/green look inverted vs /debts and Dashboard (there, receivable is a labeled owner-POV bucket). | Designed: Debts/Dashboard stay owner-POV; partner surfaces are partner-POV. Cross-screen color difference is not a bug. |
+| Summary-strip figures carry no signs (receivable red / payable green / net neutral + direction word). | Aggregate buckets are unsigned by design; only single balances are signed. |
+| Partner detail has a right rail — shared-checklist §3 says «missing rail on Partner is correct» (#20g/DR-01: stacked). | Working-tree decision (DEC-8) supersedes; don't report the rail as a layout defect, but note the #20g conflict for canon sync. |
+| Header shows type chip + company after the name (titleExtra). | #20e open ruling on titleExtra — existing usage, not a defect. |
+| «Обороты» rail card sums ledger deltas client-side. | Display subtotals of served deltas — not a recomputed balance; no R12 violation. The balance itself is served. |
+| Opening ledger row: tinted, not clickable, date without time, «—» in «Номер». | Designed — opening is a synthetic event (id 0, no source record). |
+| Zero balance renders «—» in the list column (detail shows «0» + «Баланс закрыт — обязательств нет»). | Designed muting of settled partners. |
+| Form type control shows short «Оба»; chips elsewhere show «Клиент + Поставщик». | #15 governs chips; the compact form label is a localized short form, not a raw enum leak. |
+| Archived partner selectable in the **Template** form partner picker. | Known F15 — belongs to `modules/templates.md` (Wave 2); do not test or report here. |
+
+## Happy path
+
+Run-scoped entities: «QA-<MMDD> Партнёр А» (T-PRT-01), «QA-<MMDD> Партнёр Б» (T-PRT-34), «QA-<MMDD> Партнёр В» (T-PRT-36). Deep passes run in doc order — later cases build on earlier data.
+
+### T-PRT-01 · Create partner with opening balance [happy]
+Pre: /partners, QA org.
+Steps: 1) «Новый партнёр». 2) Name «QA-<MMDD> Партнёр А», type «Поставщик», phone national part `901234567`. 3) Opening: «Партнёр должен нам», amount 50 000 — note the red «−» sign preview and «Стартовая запись в книге: −50 000 UZS». 4) Submit «Создать партнёра».
+Expect: toast «Партнёр «QA-<MMDD> Партнёр А» создан»; row appears with balance «−50 000» red (partner-POV — see Traps); phone renders with fixed «+998» prefix. Opening is a signed immutable event; `openingDate` is server-set to today — visible on the detail rail as «Начальный баланс: <today DD.MM.YYYY> — −50 000 UZS» (contract: create; R12).
+
+### T-PRT-02 · Detail page structure, rail, count pills [happy]
+Pre: partner А (T-PRT-01).
+Steps: 1) Open А from the list. 2) Inspect header, rail, tabs.
+Expect: header = name + type chip «Поставщик» + no meta beyond titleExtra (#20e, Traps); rail balance hero «−50 000» red + hint «Дебиторская задолженность — партнёр должен нам»; opening strip per T-PRT-01; «Обороты» rows Продажи/Поставки/Платежи all «—» (zero); «Контакты» lists the phone. Tabs «Журнал 1 · Транзакции 0 · Платежи 0» (#20b). Транзакции tab shows empty state «Партнёр только создан — пока есть только начальный баланс…».
+
+### T-PRT-03 · Ledger opening row semantics [happy]
+Pre: partner А.
+Steps: 1) Журнал tab.
+Expect: exactly one row — «Номер» = «—», date **without** time, event «Начальный баланс», Сумма «−50 000» red, «Баланс после» «−50 000»; row is tinted and clicking it does nothing (contract: ledger opening event, sourceId null).
+
+### T-PRT-04 · Edit preserves served balance (F2 regression watch) [happy]
+Pre: partner А.
+Steps: 1) Detail ⋮ → edit. 2) Set company «QA Компания». 3) «Сохранить изменения».
+Expect: toast «Изменения сохранены»; balance still «−50 000» immediately, **without reload** (update re-reads by id). F2 is FIXED — a «—»/«не число»/NaN/0 balance after edit is a **NEW regression**: report FAIL, not KNOWN.
+
+### T-PRT-05 · Supply creates a signed ledger row with running balance [happy] ✍
+Pre: partner А; fixtures «QA Склад А», «QA Товар Штучный» (supply 10 000).
+Steps: 1) /supplies/new: partner А, warehouse «QA Склад А», «QA Товар Штучный» ×10 (total 100 000), no payment, submit. 2) Back to А → Журнал.
+Expect: new supply row on top (date-desc default): event «Поставка», Сумма «+100 000» green (we owe more, partner-POV), «Баланс после» «+50 000» = −(50 000 − 100 000) green; balance card now «+50 000» green + hint «Кредиторская задолженность — мы должны партнёру»; «Обороты» Поставки = 100 000; pills «Журнал 2 · Транзакции 1 · Платежи 0» (R12).
+Known: F20 — the supply row's «Номер» shows «—» (backend serves no `reference` on sale/supply rows); payment rows do show it. KNOWN, not new.
+
+### T-PRT-06 · Deep link lands on filtered Транзакции tab [happy]
+Pre: partner А with the open supply debt (T-PRT-05).
+Steps: 1) Navigate directly to `/partners/<id А>?tab=transactions&status=open`. 2) Also: /debts → По партнёрам → click А and note whether the link carries the same params.
+Expect: Транзакции tab active, status filter preset «Открытые — долг», showing exactly the unpaid supply (status chip «Не оплачено», Сумма 100 000). `open` = unpaid ∪ partial. Refresh keeps the filtered landing.
+
+### T-PRT-07 · Payment settles debt; ledger and balance reconcile [happy] ✍
+Pre: partner А (open supply 100 000).
+Steps: 1) Payments page → create payment: type «Оплата», partner А, wallet «QA Касса», amount 100 000, submit (exact amount — no settlement modal, #5). 2) А → Журнал.
+Expect: payment row: event «Оплата», Сумма «−100 000» red (their claim shrank, partner-POV), «Баланс после» «−50 000» red; «Номер» carries the payment's document number (verify against canon DR-21 — bare `N` vs «№N»); wallet «QA Касса» resolvable on the row/payments tab. Balance card back to «−50 000» red. «Обороты» Платежи = 100 000. Pills «Журнал 3 · Транзакции 1 · Платежи 1». Транзакции tab: supply now «Оплачено» (R8, R12).
+
+### T-PRT-08 · PartnerType Both chip [happy]
+Pre: partner А.
+Steps: 1) Edit А → type «Оба» → save. 2) Check list row and detail header.
+Expect: chip renders «Клиент + Поставщик» in both places — raw «Both» never shown (#15).
+
+### T-PRT-09 · Archive never blocked; history resolves; picker excludes [happy]
+Pre: partner А (referenced by a supply + payment).
+Steps: 1) ⋮ → archive → confirm «Архивировать QA-<MMDD> Партнёр А?». 2) List: check «Активные» then «Архив». 3) /supplies list: find the T-PRT-05 row. 4) /supplies/new: search А in the partner picker. 5) Open А's detail. 6) Restore.
+Expect: archive succeeds despite references (R30); toast «QA-<MMDD> Партнёр А — в архиве»; row gone from «Активные», present under «Архив» with badge «в архиве» (#13); the historical supply row still shows А's name (R30); POS picker does NOT offer А; detail shows banner «Партнёр в архиве.» with balance intact (R31 context). Restore returns А to the active list with toast «…восстановлен из архива».
+
+## Edge & negative
+
+### T-PRT-30 · Empty submit reports inline, button stays enabled [negative]
+Pre: create form open.
+Steps: 1) Submit with all fields empty.
+Expect: submit is clickable (hard rule 5); inline errors — name «Имя должно содержать минимум 2 символа», phones «Укажите хотя бы один номер телефона»; no top-of-form banner (DR-24, #18); modal stays open, no request fires.
+
+### T-PRT-31 · Per-row phone validation [negative]
+Pre: create form; name filled valid.
+Steps: 1) Phone row 1: valid `901234567`. 2) «Добавить телефон», row 2: `12`. 3) Submit.
+Expect: only row 2 errors — «Телефон должен содержать только цифры (опционально «+») и иметь 7-15 символов» under that row; row 1 unaffected; submit blocked until fixed.
+
+### T-PRT-32 · Telegram round-trip — verify live [edge]
+Pre: partner А.
+Steps: 1) Edit А → Telegram «@qa_prt_check» → save. 2) Hard-reload the detail page. 3) Check «Контакты» in the rail.
+Expect: **contested** — F12 says the contract has no telegram field, so the value is silently discarded (blank after reload = KNOWN F12); the tracker claims it is now served. Report which behavior is live; if it persists, report «F12 may be fixed — verify and update frontend-gaps.md».
+Known: F12.
+
+### T-PRT-33 · Opening balance immutable — edit form offers no input [edge]
+Pre: partner А.
+Steps: 1) Open edit for А. 2) Inspect the «Начальный баланс» section.
+Expect: read-only locked card — «Начальный баланс», «Записан <date> — изменить нельзя», signed amount, helper explaining the current balance moves only via transactions/payments; **no** type/amount inputs anywhere (contract: `UpdatePartnerRequest` has no opening fields; R1-adjacent audit event).
+
+### T-PRT-34 · Zero balance rendering [edge]
+Pre: /partners.
+Steps: 1) Create «QA-<MMDD> Партнёр Б», type «Поставщик», valid phone, opening «Партнёр должен нам» amount 0. 2) Check list row and detail.
+Expect: list balance cell «—» (muted, not «0»); detail hero «0» neutral + «Баланс закрыт — обязательств нет»; ledger has the opening row with Сумма «0».
+
+### T-PRT-35 · Delete gated by served isDeletable — referenced partner [negative]
+Pre: partner А (referenced).
+Steps: 1) List row ⋮ → «Удалить».
+Expect: delete control is visible (never hidden, #19); dialog «Партнёра нельзя удалить» explaining references, offering «Архивировать» instead (DR-20, R32); no DELETE request fires on open. Cancel — do not archive.
+
+### T-PRT-36 · Fresh unreferenced partner hard-deletes [edge]
+Pre: /partners.
+Steps: 1) Create «QA-<MMDD> Партнёр В» (type «Клиент», valid phone, opening 0). 2) Row ⋮ → «Удалить» → confirm dialog «Удалить QA-<MMDD> Партнёр В?» → «Удалить».
+Expect: dialog warns irreversibility; DELETE returns 204; toast «Партнёр «QA-<MMDD> Партнёр В» удалён»; row gone from both «Активные» and «Архив» (R32, DR-20 — served `isDeletable=true` routes to the real delete dialog).
+
+### T-PRT-37 · Ledger filters and search [edge]
+Pre: partner А (3 ledger rows).
+Steps: 1) Журнал: event filter «Оплаты». 2) Reset; filter «Поставки». 3) Reset; search `100`. 4) Filter «Начальный баланс». 5) Filter «Возвраты» — А has no refunds.
+Expect: each filter narrows to only matching rows (pager count follows the filtered set); search matches event label/number/amount text — search `100` matches TWO rows, the supply AND the payment (both amounts are 100 000; digits match unformatted, so a spaced fragment like «100 000» matches nothing); «Начальный баланс» shows only the opening row; «Возвраты» yields the empty state «Нет записей» + «По выбранному фильтру событий не найдено» (#14 — filters live inside the table widget).
+
+## Reconciliation
+
+### T-PRT-60 · Headline: balance card ↔ ledger ↔ /debts ↔ open transactions [reconcile] ✍
+Pre: partner Б (opening 0, from T-PRT-34); fixtures «QA Склад А», «QA Товар Штучный».
+Steps: 1) /supplies/new: partner Б, «QA Товар Штучный» ×18 (total 180 000), no payment, submit. 2) Б's detail: read the balance card. 3) Журнал: read «Баланс после» of the newest row. 4) Транзакции tab, filter «Открытые — долг»: sum the amounts. 5) /debts → По партнёрам: find Б's row; По транзакциям: find the supply.
+Expect: one number four ways — balance card «+180 000» green = ledger last running balance «+180 000» = /debts remaining for Б 180 000 (payable direction) = sum of open transactions 180 000 (single row, «Не оплачено»). Any divergence is a Blocker-grade defect in the dispute-grade ledger (R12; ledger contract: running balance reconciles exactly to the net balance).
+
+### T-PRT-61 · Balance includes opening; /debts excludes settled [reconcile]
+Pre: partner А settled (T-PRT-07: opening −50 000 display, supply paid).
+Steps: 1) А detail: balance card. 2) /debts (both tabs): search А.
+Expect: balance card «−50 000» red — the opening event alone (50 000 receivable + 0 open transactions); А appears **nowhere** on /debts (its only transaction is fully paid; /debts is a transactions-only read model, not the partner balance). This asymmetry is by design — an opening-balance debt is visible on the partner, not on /debts (contract: debts notes; R12).
+
+### T-PRT-62 · Summary strip self-consistency [reconcile]
+Pre: /partners, «Активные» view, partners А and Б present (post T-PRT-60).
+Steps: 1) Set pager to 50; type filter «Все». 2) Sum the red («−») balance cells and the green («+») balance cells across all active rows. 3) Compare with the strip.
+Expect: «Всего к получению» = sum of red balances (unsigned); «Всего к оплате» = sum of green; «Чистая позиция» = |receivable − payable| with the direction word («в нашу пользу» when receivable ≥ payable); the receivable/payable card subtitles count contributing partners («N партнёров должны нам» / «мы должны N партнёрам»); the net card subtitle counts ALL active partners («N активных»), zero-balance included; archived partners excluded from all three.
+Known: REC-3 — the strip once rendered all-zero counts (unreconciled). If reproduced, report KNOWN with exact repro detail (filters, timing, data state), not a new defect.
+
+### T-PRT-63 · Count-pill arithmetic [reconcile]
+Pre: partner А (post T-PRT-07).
+Steps: 1) А detail: read the three tab pills.
+Expect: Журнал = Транзакции + Платежи + 1 (the opening row): «3 = 1 + 1 + 1». The tabs are pure partitions of one served ledger — a mismatch means rows are dropped or double-counted between tabs.

--- a/docs/testing/modules/payments.md
+++ b/docs/testing/modules/payments.md
@@ -1,0 +1,147 @@
+# Payments — test cases (T-PAY)
+
+Standalone payments: the five immutable payment types, the source/allocation model (business-rules §B), settlement, advance gating, and cross-screen money consistency. Read with [../README.md](../README.md) · [../shared-checklist.md](../shared-checklist.md) · [../fixtures.md](../fixtures.md) · [../../frontend-gaps.md](../../frontend-gaps.md).
+
+Run-scoped entities are named «QA-<MMDD> …» — substitute the run date. Cases build on earlier cases' data; run in doc order. Amount arithmetic below assumes the doc's own flow only — a re-run needs fresh run-scoped entities.
+
+## Surfaces
+
+- `/payments` — list: `PaymentHeader` («Новый платёж», «Экспорт», search «Поиск по номеру, партнёру или сотруднику…», type dropdown «Все типы», wallet dropdown «Все кассы»), `PaymentSummaryStrip` (clickable «Приход»/«Расход» toggle cards + «Платежей» count), `PaymentsTable` (row click → detail; no actions column).
+- `/payments/:id` — detail: right-rail layout (#20g). Main column: per-type card (payroll/general/withdrawal) + «Касса» source card + «Распределение» allocation table; rail: «Информация» card.
+- `PaymentCreateModal` (type picker + per-type fields) and `PaymentSettlementModal` («Распределение платежа») — both launched from the list page.
+- `/payments/new` — placeholder page; smoke.md owns it, no cases here.
+- Payroll payments created on employee detail also land in this list (type «Зарплата») — the list rendering is in scope here; the employee-side flow is T-EMP.
+
+## Traps
+
+- **Settlement modal opens on every standalone «Оплата» submit** (button reads «Распределить и провести»), including at zero debt. Pattern #5 («only on overpayment») governs the guided POS flow; the standalone modal stays functionally as-is per DR-05. Not a bug.
+- **DR-05 — allocation-ordering semantics are deferred.** Assert only what's served: `/api/payments/outstanding` is oldest-first and «Авто (по порядку)» fills that order top-down. Do NOT write up mixed sale/refund ordering, direction-vs-debt-position outcomes, or expect a partner-page «оплатить долги» button.
+- **«В аванс» shows for any unallocated remainder** even while debt rows sit unchecked — the R40 gate is server-side (see T-PAY-36); the visible figure is not a #6 violation.
+- **Transaction references show «№{id}», not the document number.** `OutstandingTransactionDto` and `PaymentAllocationEntryDto` serve no display `number`, so the settlement modal and the detail's «Распределение» label rows via the internal transactionId. A mismatch against the transaction's own «№N» is a contract gap (same class as F20) — report as an F-item observation, not a settlement failure. Click-through must still land on the right transaction.
+- **No `⋮` actions column on the payments list at all** — payments are immutable (R1); row click opens the detail. Not a #21 violation.
+- **Type picker exists only in this standalone modal** (R13). Guided flows (POS payment, transaction «Оплатить», employee payroll) fix the type by context — no type control there is correct.
+- **Direction control is usually absent** — derived per R14. It appears only for a «Both» partner (label «Направление (партнёр типа «Оба»)») and always for «Общий».
+- **Withdrawal detail renders a «Возврат аванса» card**, not a «Распределение» table — designed rendering.
+- **Income payments have no wallet-balance guard** — only Expense-direction draws are blocked (DR-25).
+- **Dual payroll paths** (standalone modal + employee detail) are both valid; any number of payroll payments per employee+month (R1).
+- **Payment detail has no notes/attachments sections** — Known F18 (backend gap), don't report as missing UI.
+
+## Happy path
+
+### T-PAY-01 · Run-scoped setup [happy] ✍
+Pre: QA org, fixtures seeded ([../fixtures.md](../fixtures.md)).
+Steps: 1. Create wallet «QA-<MMDD> Касса-П» (Cash, opening 1 000 000). 2. Create partner «QA-<MMDD> Плательщик» (Клиент, opening balance 0). 3. Create product «QA-<MMDD> Товар-П» (category «QA Категория», шт, supply 60 000 / sale 100 000). 4. On «QA Склад А» → «Начальный остаток»: 20 × «QA-<MMDD> Товар-П» @ 60 000.
+Expect: all four created; wallet detail shows balance 1 000 000; partner detail balance hero «0» (neutral) + hint «Баланс закрыт — обязательств нет» (partner-POV signed display — see modules/partners.md Traps; #4 amendment pending).
+
+### T-PAY-02 · Seed an open debt via POS sale [happy] ✍
+Pre: T-PAY-01.
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Плательщик», warehouse «QA Склад А», 6 × «QA-<MMDD> Товар-П» @ 100 000 (total 600 000). 2. Leave payment 0 → «Провести продажу» → confirm «Провести в долг» in the «Провести без оплаты?» dialog.
+Expect: sale created; status chip «Не оплачено» in `/sales`; partner balance shows they owe 600 000 (partner-POV signed display on partner detail — see modules/partners.md POV trap).
+
+### T-PAY-03 · Worked example (a): overpayment → settlement + advance [happy] ✍
+Pre: T-PAY-02 (open 600 000 debt).
+Steps: 1. `/payments` → «Новый платёж»: type «Оплата», partner «QA-<MMDD> Плательщик», wallet «QA-<MMDD> Касса-П», amount 1 000 000. 2. Submit «Распределить и провести». 3. In «Распределение платежа»: verify auto-FIFO preallocated 600 000 to the sale; «К распределению» 1 000 000, «Распределено» 600 000, «В аванс» 400 000 + note «Зачислится как аванс партнёра». 4. «Провести платёж».
+Expect: success toast «Платёж … проведён»; new row in the list. Detail: «Касса» card = «QA-<MMDD> Касса-П» 1 000 000 (single source, R9); «Распределение» rows: «Продажа №…» / «Погашение транзакции» 600 000 and «Аванс партнёра» / «Зачисление аванса» 400 000 — settling allocations sum = source sum (R8); «Информация»: Тип «Оплата», Направление «Приход» (derived, R14).
+Known: F9 — if the «Распределение» block crashes on an unexpected allocationType, report KNOWN. F18 — no notes/attachments sections.
+
+### T-PAY-04 · Worked example (c): change return — memo only [happy] ✍
+Pre: T-PAY-03 (partner debt 0). Wallet «QA-<MMDD> Касса-П» = 2 000 000.
+Steps: 1. `/sales/new`: same partner/warehouse, 4 × «QA-<MMDD> Товар-П» (total 400 000). 2. Payment section: 500 000 from «QA-<MMDD> Касса-П»; leave the overpayment toggle on «Сдача» (the default, #5, R40). 3. Submit.
+Expect: sale Closed («Оплачено»). In `/payments` the generated «Оплата» payment's detail: «Касса» source = **400 000** — net of change (R15); «Распределение»: «Погашение транзакции» 400 000 + «Сдача» 100 000 on a muted row with the «памятка» tag (R10 — memo, outside the R8 identity). Wallet balance = 2 400 000 (+400 000, not +500 000); the 100 000 appears in neither wallet operations nor partner balance (R10, R15). Partner detail still shows the zero-balance state — hero «0» + «Баланс закрыт — обязательств нет» (see [partners.md](partners.md) POV trap).
+
+### T-PAY-05 · Вывод — return the advance [happy] ✍
+Pre: T-PAY-03 gave the partner a 400 000 advance. Wallet = 2 400 000.
+Steps: 1. «Новый платёж»: type «Вывод», partner «QA-<MMDD> Плательщик» — the hint row shows «Аванс: 400 000 UZS». 2. Wallet «QA-<MMDD> Касса-П», amount 400 000. 3. «Провести платёж» (no settlement step).
+Expect: no direction control (Customer → derived Expense, R14). Detail: «Возврат аванса» card with «Возврат аванса партнёру» 400 000 (red); «Информация» Направление «Расход». Wallet = 2 000 000; reopening the create modal, selecting type «Вывод» and picking the partner shows «Аванс: 0 UZS» (the advance segment of the hint renders only for type «Вывод» once the advance is 0).
+
+### T-PAY-06 · Депозит — create an advance [happy] ✍
+Pre: T-PAY-05. Wallet = 2 000 000, partner advance 0.
+Steps: 1. «Новый платёж»: type «Депозит», partner «QA-<MMDD> Плательщик», wallet «QA-<MMDD> Касса-П», amount 150 000. 2. Submit.
+Expect: no direction control (single-type partner → derived, R14). Wallet = 2 150 000. Create-modal hint for the partner now «Баланс: 0 UZS · Аванс: 150 000 UZS» (advance is a claim on cash in the wallet, R11). Detail «Распределение» shows «Аванс партнёра» / «Зачисление аванса» 150 000 (verify against canon R10/R11 — served allocation shape for deposits).
+
+### T-PAY-07 · Общий — direction user-set, description required [happy] ✍
+Pre: T-PAY-06. Wallet = 2 150 000.
+Steps: 1. «Новый платёж»: type «Общий» — a «Приход | Расход» segmented control appears (always user-set, R14) and «Описание» is required (contract validation). 2. «Расход», description «QA-<MMDD> аренда», wallet «QA-<MMDD> Касса-П», amount 50 000. 3. Submit.
+Expect: created; list row party column shows «—» (no partner/employee); detail has an «Описание» card with the entered text; wallet = 2 100 000.
+
+### T-PAY-08 · Зарплата via the standalone modal [happy] ✍
+Pre: T-PAY-07. Fixture «QA Сотрудник» (salary 3 000 000). Wallet = 2 100 000.
+Steps: 1. «Новый платёж»: type «Зарплата» → employee select + «Период» (month/year) replace the partner field. 2. Pick «QA Сотрудник» — amount autofills 3 000 000; replace with 200 000. 3. Wallet «QA-<MMDD> Касса-П», submit.
+Expect: no direction control (Payroll → always Expense, R14). List row: chip «Зарплата», party «QA Сотрудник». Detail payroll card: Сотрудник / Должность / Период «<месяц> <год>» / Оклад 3 000 000 / Выплачено 200 000. Wallet = 1 900 000.
+
+### T-PAY-09 · List anatomy and the five type labels [happy]
+Pre: T-PAY-03…08 created one payment of each type.
+Steps: 1. Open `/payments`; sort default date-desc. 2. Scan the run's rows.
+Expect: columns «Платёж» (copyable «№N») · «Дата» (date+time) · «Партнёр / Сотрудник» (partner rows link to partner detail) · «Тип операции» with the real localized type — «Оплата», «Депозит», «Вывод», «Зарплата», «Общий» all present (#17) · «Направление» («Приход» green / «Расход» red pills) · «Касса» (wallet link) · «Сумма» right-aligned, unsigned, green/red by direction (#4). No `⋮` column (R1 — see Traps).
+
+### T-PAY-10 · Filters and summary-card toggle [happy]
+Pre: T-PAY-09.
+Steps: 1. Search «QA-<MMDD> Плательщик». 2. Clear; type filter «Депозит». 3. Clear; wallet filter «QA-<MMDD> Касса-П». 4. Click the «Расход» summary card; click it again. 5. Combine search with a non-matching type.
+Expect: 1 → only this run's partner's payments. 2 → all visible rows are type «Депозит» and the run's 150 000 deposit is among them (the filter is org-wide and may include deposits from earlier runs). 3 → only the run wallet's payments. 4 → first click filters to Expense rows and highlights the card; second click clears; «Приход»/«Расход» card totals do NOT change when the direction toggle flips (they total the scoped view). 5 → empty state «Платежи не найдены» / «Измените запрос поиска или фильтры по типу и кассе.»
+
+## Edge & negative
+
+### T-PAY-30 · Worked example (b): pay from advance + cash — expressibility probe [edge]
+Pre: partner advance 150 000 (T-PAY-06).
+Steps: 1. `/sales/new`: pick «QA-<MMDD> Плательщик»; inspect the payment section for any control that draws from the partner's advance. 2. Open the standalone «Новый платёж» modal, type «Оплата», same partner — the hint shows «Аванс: 150 000 UZS»; inspect for an advance-source control.
+Expect: canon target (R9/R11): a 1 000 000 sale paid 500 000 advance + 500 000 cash → two sources (Advance + Wallet), wallet moves +500 000 only, advance claim consumed. Current contract cannot express an Advance source in either write path (frontend-gaps A2) — if no affordance exists (expected), record **BLOCKED (A2)**, create nothing. If an affordance exists, execute with 150 000 advance + cash and verify the wallet moves only by the cash half (R11).
+
+### T-PAY-31 · Вывод exceeding the advance is blocked [negative]
+Pre: partner advance 150 000.
+Steps: 1. «Новый платёж»: «Вывод», partner «QA-<MMDD> Плательщик», wallet «QA-<MMDD> Касса-П», amount 200 000. 2. «Провести платёж».
+Expect: inline error under amount «Аванс партнёра: 150 000 UZS. Нельзя вывести больше.»; button stays enabled (#7) but nothing is created — no new list row, no POST 201.
+
+### T-PAY-32 · Expense exceeding wallet balance is blocked [negative]
+Pre: «QA-<MMDD> Касса-П» = 1 900 000 (after T-PAY-08).
+Steps: 1. «Новый платёж»: «Общий», «Расход», any description, wallet «QA-<MMDD> Касса-П», amount 5 000 000. 2. Submit.
+Expect: inline error «Доступно только 1 900 000 UZS — нельзя списать больше остатка кассы.» (DR-25); nothing created. Switching direction to «Приход» clears the block (no guard on inflows — Traps).
+
+### T-PAY-33 · Direction control appears only for «Both» [edge]
+Pre: fixtures «QA Универсал» (Both), «QA Клиент», «QA Поставщик».
+Steps: 1. «Новый платёж» → «Депозит», partner «QA Универсал». 2. Switch partner to «QA Клиент», then «QA Поставщик». 3. Type «Вывод», partner «QA Универсал». 4. Close without saving.
+Expect: 1 and 3 → segmented «Приход | Расход» labeled «Направление (партнёр типа «Оба»)» (R14 — user-set for Both). 2 → control absent for both single types (derived). No writes.
+
+### T-PAY-34 · Per-type required-field messages [negative]
+Pre: create modal open.
+Steps: 1. Type «Оплата», submit empty. 2. Type «Общий», fill wallet+amount, leave description empty, submit. 3. Close (confirm discard).
+Expect: 1 → inline «Выберите партнёра», «Выберите кассу», «Введите сумму платежа» (contract validation; DR-24 — no top banner). 2 → «Укажите описание платежа». Nothing created.
+
+### T-PAY-35 · Manual distribution: cap and re-auto [edge] ✍
+Pre: T-PAY-08 done. Wallet = 1 900 000.
+Steps: 1. `/sales/new`: 3 × «QA-<MMDD> Товар-П» (300 000) to «QA-<MMDD> Плательщик», unpaid → new open sale. 2. «Новый платёж»: «Оплата», same partner/wallet, amount 200 000 → settlement modal. 3. In the sale's row type 999 999 999. 4. Set the row to 150 000; observe totals. 5. Click «Авто (по порядку)». 6. «Провести платёж».
+Expect: 3 → input clamps to 200 000 (≤ min(row remaining, payment amount) — contract: settlement amount must not exceed remaining). 4 → «Распределено» 150 000, «В аванс» 50 000. 5 → FIFO restored: 200 000 allocated, «В аванс» 0. 6 → payment created with one settlement 200 000; the sale flips to «Частично» (PartiallyPaid), remaining 100 000; wallet = 2 100 000.
+
+### T-PAY-36 · Unallocated remainder with open debt — advance must not be created [edge] ✍
+Pre: T-PAY-35 (sale remaining 100 000). Wallet = 2 100 000.
+Steps: 1. «Новый платёж»: «Оплата», same partner/wallet, amount 50 000 → settlement modal. 2. Uncheck the sale's row — «Распределено» 0, «В аванс» 50 000. 3. «Провести платёж». 4. Open the created payment's detail; check `POST /api/payments` in the network log.
+Expect: (verify against canon R40 / contract `POST /api/payments` notes) the request carries empty `settlements`; the backend then settles oldest-first — detail «Распределение» must show «Погашение транзакции» 50 000 against the open sale and **no «Зачисление аванса»** row, sale remaining 50 000. An AdvanceCredit created while debt remains is a FAIL (R40). Wallet = 2 150 000 either way.
+
+### T-PAY-37 · Zero-debt settlement empty state; close the sale [edge] ✍
+Pre: T-PAY-36 (sale remaining 50 000).
+Steps: 1. «Новый платёж»: «Оплата», same partner/wallet, amount 50 000 → settlement modal auto-allocates 50 000 → «Провести платёж». 2. Reopen «Новый платёж», «Оплата», same partner, wallet, amount 10 000 → submit to the settlement modal. 3. «Назад», close without saving.
+Expect: 1 → sale flips to «Оплачено» (Closed); wallet = 2 200 000. 2 → empty state «Открытых долгов нет» / «Вся сумма будет записана как аванс партнёра» — the advance path offered only now, at zero outstanding debt (R40, #6). 3 → no payment created.
+
+## Reconciliation
+
+### T-PAY-60 · Transaction status flips propagate across screens [reconcile]
+Pre: full happy+edge flow done (T-PAY-35→37 walked one sale Open → PartiallyPaid → Closed).
+Steps: 1. `/sales`: locate the three run sales. 2. Open each sale's detail. 3. Partner detail → «Транзакции» tab. 4. `/debts`, search «Плательщик».
+Expect: all three sales show «Оплачено» (Closed) consistently in list chips, detail status, and the partner's Транзакции tab; `/debts` has no rows for «QA-<MMDD> Плательщик». The T-PAY-35 intermediate state («Частично», remaining 100 000) must have been visible at that step — if it was skipped, re-check before closing.
+
+### T-PAY-61 · Wallet operations ledger matches the payment chain [reconcile]
+Pre: all prior cases. Expected deltas on «QA-<MMDD> Касса-П»: opening 1 000 000; +1 000 000 (T-PAY-03); +400 000 (04); −400 000 (05); +150 000 (06); −50 000 (07); −200 000 (08); +200 000 (35); +50 000 (36); +50 000 (37).
+Steps: 1. Open the wallet's detail → «Операции» tab. 2. Compare each row's amount and «Баланс после» against the chain. 3. Read the header stat cards.
+Expect: one operation per event above, running «Баланс после» consistent, final = **2 200 000** = header balance; «Авансы» = 150 000; «Наши средства» = 2 050 000 (R12 — served, not recomputed). No operation for the 100 000 change from T-PAY-04 (R10/R15).
+Known: F10 — if direction pills render all-red or a row misses a party link, report KNOWN.
+
+### T-PAY-62 · Partner balance agrees everywhere [reconcile]
+Pre: all prior cases. Expected end state: debt 0, advance 150 000.
+Steps: 1. Partner detail: balance card + «Платежи» tab. 2. «Новый платёж» modal → pick the partner, read the hint row. 3. `/payments` filtered to the partner (search).
+Expect: balance card «0» neutral + «Баланс закрыт — обязательств нет» (partner-POV signed display, modules/partners.md Traps; #4 amendment pending); modal hint «Баланс: 0 UZS · Аванс: 150 000 UZS»; the partner's «Платежи» tab lists the same payments («№N», amounts, dates) as the filtered `/payments` list — no row present in one and missing in the other; amounts identical to each payment detail's «Касса» sum.
+Known: F20-class — sale/supply rows in the partner ledger may show «—» in the number column (backend gap).
+
+### T-PAY-63 · Payment ↔ transaction cross-links and numbers [reconcile]
+Pre: T-PAY-03 payment and T-PAY-02 sale.
+Steps: 1. Open the T-PAY-03 payment detail; click the «Продажа №…» allocation row. 2. On the sale detail, find the «Платежи» section; note the payment's number and amount. 3. Navigate back to the payment via that reference.
+Expect: allocation click lands on the correct sale (600 000 settled); the sale's payments section shows the same payment with amount 600 000 (the settled slice, not the 1 000 000 total) and a «№N» that matches the payment detail's title; round-trip returns to the same payment.
+Known: allocation label «№{id}» may not equal the sale's own «№N» (Traps — contract gap, report as observation).

--- a/docs/testing/modules/refunds.md
+++ b/docs/testing/modules/refunds.md
@@ -1,0 +1,136 @@
+# Refunds — test cases (T-RFD)
+
+SaleRefund / SupplyRefund counter-events: creation from the original, caps, effects on stock/debt/balance. Pairs with [../README.md](../README.md) · [../shared-checklist.md](../shared-checklist.md) · [../fixtures.md](../fixtures.md) · gaps: F8, F20, F19 (resolved F6). Canon: business-rules §A (R1–R7), §D (R18–R20); ui-patterns behavior digest «Refunds (R2–R7)»; contract `transactions-payments.md` (POST /api/transactions refund validation).
+
+## Surfaces
+
+- **No standalone route.** Refund create = `RefundModal`, opened only from the original's detail (`/sales/:id`, `/supplies/:id`) via ⋮ kebab → «Создать возврат» — the kebab's only row («Скачать» is the separate visible header button).
+- **Refund rows** live inside the `/sales` feed (SaleRefund) and `/supplies` feed (SupplyRefund).
+- **Refund detail** = the same `TransactionDetailPage` route, rendering refund-specific parts: clickable «Возврат к продаже/поставке» banner, «Причина возврата» card, «Сумма возврата» financial card. No kebab at all on a refund detail.
+- **Wire:** refunds POST through the shared multipart `POST /api/transactions` with `Type=SaleRefund|SupplyRefund` + `OriginalTransactionId` + `RefundReason` — no dedicated refund route.
+
+## Traps
+
+Module-specific designed behavior — never report these (shared-checklist §6 traps not repeated):
+
+| Observation | Why it's correct |
+| --- | --- |
+| Refund rows show «—» in «Статус» and vanish entirely when any status filter is active | refunds carry no payment status (`TransactionStore.feedFor`, design parity) |
+| Refund amount «−…» renders muted gray, not red | green/red reserved for money-direction figures (#4) |
+| Success toast «Возврат к №N проведён» cites the ORIGINAL's number, not the new refund's | by design (`transaction.refund.success`) |
+| Checking a line in the modal pre-fills the full available quantity | convenience default, editable |
+| Refund detail has no payments card and no status chip | an unpaid refund's debt surfaces on /debts and the partner ledger, not on its own detail |
+| «Скачать» on any transaction detail → toast «… — раздел в разработке» | dev stub, not a defect |
+| Warehouse «Движения» filter «Возврат» matches zero rows | Known F8 — verify refund movements in the unfiltered list |
+
+## Happy path
+
+### T-RFD-01 · Run-scoped books: partner, products, original sale [happy] ✍
+Pre: QA org; fixtures «QA Склад А», «QA Касса». All later cases build on this data — run in doc order. Record document numbers as you go: №S (sale), №R1/№R2/№R3 (refunds).
+Steps:
+1. Create partner «QA-<MMDD> Возврат Партнёр» (type «Клиент + Поставщик», opening balance 0).
+2. Create products «QA-<MMDD> Возврат А» and «QA-<MMDD> Возврат Б» (piece unit, no packaging, supply 10 000 / sale 15 000).
+3. `/supplies/new`: partner above, «QA Склад А», line А×10 @ 10 000 = 100 000; pay 100 000 fully from «QA Касса».
+4. `/sales/new`: same partner/warehouse, line А×5 @ 15 000 = 75 000, no discount, paid 0. Record №S.
+5. Open `/partners/:id` of the run partner and capture `GET /api/partners/{id}` from the network.
+Expect: sale №S detail — «Итого» 75 000, «Оплачено» 0, «Остаток» 75 000, status «Не оплачено»; «QA Склад А» → Остатки: product А qty 5 (10−5, R19); network `GET /api/partners/{id}` → `balance: 75000` (R12).
+
+### T-RFD-02 · First SaleRefund: 3 of 5, mandatory reason [happy] ✍
+Pre: T-RFD-01.
+Steps:
+1. On `/sales/:id` of №S: ⋮ → «Создать возврат».
+2. Verify modal title «Возврат к продаже №S»; meta row shows partner, warehouse, date; line А: «Продано» 5, «Возвращено» «—», «Доступно» 5 (R5).
+3. Check the line — qty pre-fills 5; change to 3. Footer reads «Позиций к возврату: 1» · «Сумма возврата: −45 000 UZS» (3 × 15 000).
+4. Verify «Причина возврата» label carries a red asterisk (R7 — visibly marked) and the info banner «Возврат необратим…» is present (R1).
+5. Reason: «QA возврат — брак»; click «Провести возврат».
+Expect: toast «Возврат к №S проведён»; modal closes; detail refreshes; network POST carries `Type=SaleRefund`, `OriginalTransactionId` = №S's id, `RefundReason` (R2, R3 — type derived from the original, never asked).
+
+### T-RFD-03 · Refund row rendering in /sales [happy]
+Pre: T-RFD-02. Record the refund's number №R1.
+Steps: open `/sales`, default sort; locate the refund row.
+Expect: sits directly ABOVE sale №S (date-desc tie handling by design); outlined chip «Возврат» with undo icon; amount «−45 000» muted; «Статус» «—»; № cell shows №R1 with sublabel «Возврат к №S» (DR-21 — «№» prefix, no Latin prefixes).
+Known: F19 resolved F6 — a blank «Возврат к №N» sublabel is a REGRESSION; report as a new defect, not F6.
+
+### T-RFD-04 · Refund detail: content, links, no refund-of-refund [happy]
+Pre: T-RFD-03.
+Steps: click the refund row → its detail page.
+Expect: title «№R1» only (#20e); banner «Возврат к продаже» + «№S», click navigates to №S's detail; «Причина возврата» card shows the entered text; financial card «Сумма возврата» = −45 000 UZS, «Исходная продажа» = «№S» (clickable), «Позиций возвращено» 1; header has NO kebab and no refund affordance anywhere on the page (R1, R4).
+
+### T-RFD-05 · Original reflects refunded quantities [happy]
+Pre: T-RFD-04.
+Steps: on №S's detail scroll to «Возвраты по этой продаже»; then reopen ⋮ → «Создать возврат» (don't submit — close it).
+Expect: refund-history card count pill 1; row = date · «№R1» · positions 1 · reason · −45 000; row click opens №R1. Reopened modal line А: «Возвращено» 3, «Доступно» 2 (R5 — remaining = 5 − 3). Original's own figures unchanged: «Итого» still 75 000 (R1 — counter-event, not mutation).
+
+### T-RFD-06 · SaleRefund returned stock to the warehouse [happy]
+Pre: T-RFD-02.
+Steps: open «QA Склад А» detail → Остатки; find product А.
+Expect: qty = 8 (5 + 3 — SaleRefund is a stock-in, R18); unit cost/WAC for А still 10 000 (single-cost history). An unfiltered «Движения» list shows the refund movement.
+Known: F8 — the «Возврат» kind filter matches nothing; do not use it.
+
+## Edge & negative
+
+### T-RFD-30 · Submit without reason / without lines → inline errors [negative]
+Pre: T-RFD-02 (3 of 5 already refunded); modal open on №S (⋮ → «Создать возврат»).
+Steps:
+1. With no line checked and empty reason click «Провести возврат».
+2. Check line А (qty pre-fills 2), leave reason empty, submit again.
+Expect: step 1 — «Выберите хотя бы одну позицию и укажите количество к возврату.» AND reason error «Укажите причину возврата — поле обязательно» inline (R7, #18 — no banner-only, no disabled button); step 2 — only the reason error remains; NO `POST /api/transactions` fired either time. Close via Отмена (confirm discard).
+
+### T-RFD-31 · Over-cap second refund blocked client-side [negative]
+Pre: T-RFD-02 (3 of 5 already refunded).
+Steps: modal on №S; check line А; type qty 3 (available is 2); enter any reason; submit.
+Expect: row turns error-tinted with «Максимум к возврату: 2 … (уже возвращено 3 из 5)» and banner «Количество к возврату превышает доступное. Исправьте отмеченные позиции.»; «Сумма» column shows «—» for the over row; NO POST fired (R5 — cumulative cap across all refunds).
+
+### T-RFD-32 · Second refund of the remaining 2 succeeds [edge] ✍
+Pre: T-RFD-31 (modal still open).
+Steps: correct qty to 2; reason «QA возврат — остаток»; submit. Record №R2.
+Expect: footer showed «Сумма возврата: −30 000 UZS» (2 × 15 000); toast «Возврат к №S проведён» (R6 — multiple refunds allowed); «QA Склад А» Остатки: product А qty = 10 (8 + 2).
+
+### T-RFD-33 · Fully-refunded line cannot be refunded again [edge]
+Pre: T-RFD-32.
+Steps: on №S reopen ⋮ → «Создать возврат»; inspect line А; check it; enter a reason; submit.
+Expect: «Возвращено» 5, «Доступно» 0 (dimmed); checking pre-fills qty 0; submit → «Выберите хотя бы одну позицию и укажите количество к возврату.», no POST (R5). Close without saving.
+
+### T-RFD-34 · SupplyRefund blocked when the stock was already sold [negative] ✍
+Pre: T-RFD-01 (product Б exists, stock 0).
+Steps:
+1. `/supplies/new`: partner «QA-<MMDD> Возврат Партнёр», «QA Склад А», Б×5 @ 10 000 = 50 000, paid fully from «QA Касса». Record №P.
+2. `/sales/new`: same partner, Б×4 @ 15 000 = 60 000, paid fully. (Stock Б: 5 − 4 = 1.)
+3. On №P's detail: ⋮ → «Создать возврат» — modal titled «Возврат к поставке №P» (R3 — SupplyRefund from a Supply). «Доступно» shows 5 (cap tracks the original line, not stock).
+4. Check line, qty 5, reason «QA возврат поставщику», submit.
+Expect: refund NOT created — backend 400 (R20 — SupplyRefund is a stock-OUT; only 1 in stock). Current build surfaces only the generic toast «Не удалось провести возврат»; the R20 digest expects an inline error naming available-vs-requested — if only the numbers-free toast appears, log a defect candidate (no F-item exists yet). Verify via network: 400 on POST; `/supplies` gains no refund row.
+
+### T-RFD-35 · SupplyRefund within stock succeeds [edge] ✍
+Pre: T-RFD-34 (stock Б = 1).
+Steps: on №P's modal set qty 1, same reason, submit. Record №R3.
+Expect: toast «Возврат к №P проведён»; `/supplies` row: outlined chip «Возврат поставки», amount «−10 000», sublabel «Возврат к №P»; «QA Склад А» Остатки: product Б qty = 0 (stock-out at WAC, R19).
+
+### T-RFD-36 · Status filter hides refunds; search finds them by original number [edge]
+Pre: T-RFD-32.
+Steps: on `/sales` — 1. set the status filter to «Не оплачено» (the Open option); 2. reset to all, then search the bare number of №S.
+Expect: step 1 — №R1/№R2 disappear, sale №S stays (trap — designed, do not report); step 2 — results include №S AND both its refunds (search matches `originalTransactionNumber`).
+
+## Reconciliation
+
+Run after all cases above. Event ledger for «QA-<MMDD> Возврат Партнёр»: sale +75 000 unpaid; sale-refunds −45 000, −30 000 unpaid; supply of А 100 000 fully paid (net 0); supply/sale of Б fully paid (net 0); supply-refund +10 000 unpaid.
+
+### T-RFD-60 · Partner balance moves in the served direction [reconcile]
+Steps: open `/partners/:id` of the run partner; capture `GET /api/partners/{id}` from the network.
+Expect: served `balance` = 10000 exactly (75 000 − 45 000 − 30 000 + 10 000; unpaid SaleRefund = payable, unpaid SupplyRefund = receivable — BR Domain model debt definitions); the balance card renders that served value, never a client re-sum (R12). Display sign/color is partner-POV — judge per `modules/partners.md`, not owner-POV.
+
+### T-RFD-61 · Partner ledger gains a row per refund [reconcile]
+Steps: partner detail → «Журнал» tab.
+Expect: one row per event incl. all three refunds with amounts 45 000 / 30 000 / 10 000 in the directions that produce a running balance ending exactly at the served 10 000 (R12 — running balance consistent with `balance` from T-RFD-60).
+Known: F20 — «Номер» column shows «—» on transaction-sourced rows (incl. refunds); only payment rows carry a number.
+
+### T-RFD-62 · Debts view carries refund debts, net matches [reconcile]
+Steps: open `/debts`; search the run partner; check «По транзакциям» and «По партнёрам».
+Expect: «По транзакциям» has 4 open rows — №S remaining 75 000 (receivable — refunds never auto-settle the original; settlement is a payment event), №R1 45 000 and №R2 30 000 (payable), №R3 10 000 (receivable); «По партнёрам» nets the partner to 10 000 owed to us, equal to T-RFD-60's served balance (R12; owner-POV labels here — shared §5 POV trap).
+
+### T-RFD-63 · Original ↔ refund-history ↔ refund details agree [reconcile]
+Steps: №S detail «Возвраты по этой продаже»; open each refund.
+Expect: history count pill 2; rows −45 000 (№R1) and −30 000 (№R2) sum to 75 000 = the sale's full value; each refund detail's «Сумма возврата» matches its history row and its `/sales` list row; №S totals still 75 000 / paid 0 (R1).
+
+### T-RFD-64 · Stock cross-screen agreement [reconcile]
+Steps: compare «QA Склад А» Остатки rows against each product's detail per-warehouse stock.
+Expect: product А = 10 on both (10 − 5 + 3 + 2), product Б = 0 on both (5 − 4 − 1); А's WAC 10 000 on both (all stock-ins at 10 000 — R18).

--- a/docs/testing/modules/sales-supplies.md
+++ b/docs/testing/modules/sales-supplies.md
@@ -1,0 +1,148 @@
+# Sales & Supplies — test cases (T-POS)
+
+One direction-parameterized module: the `/sales` · `/supplies` feeds, transaction detail, and the full-page POS create flows. Refund creation and refund-row semantics belong to [refunds.md](refunds.md). Read with [../README.md](../README.md) · [../shared-checklist.md](../shared-checklist.md) · [../fixtures.md](../fixtures.md) · [../../frontend-gaps.md](../../frontend-gaps.md). Canon: business-rules §B (R8, R12–R14), §D (R17–R22), §K (R37–R38), R39–R40; contract `transactions-payments.md`.
+
+## Surfaces
+
+- `/sales`, `/supplies` — one `TransactionPage` (mode-parameterized): title «Продажи»/«Поставки», «Новая продажа»/«Новая поставка», «Экспорт CSV»; search «Поиск по номеру или партнёру…»/«…или поставщику…», payment-status filter, period filter («Весь период / Последние 7 / 30 / 90 дней»); columns Дата · Номер · Тип · Партнёр · Позиций · Сумма · Статус оплаты; badges «Продажа»/«Поставка» (refund badges per refunds.md); status chips «Не оплачено» (Open) / «Частично» (PartiallyPaid) / «Оплачено» (Closed) / «Просрочено» (Overdue).
+- `/sales/:id`, `/supplies/:id` — one `TransactionDetailPage` (right rail, #20g): «Позиции» table + «Подытог / Скидка по позициям / Итого» footer; rail: financial card («Сумма продажи»/«Сумма поставки», «Оплачено», «Остаток», «Статус оплаты»), «Информация» (Создано, «Склад отгрузки»/«Склад приёмки», partner), «Платежи», «Примечание и вложения».
+- `/sales/new`, `/supplies/new` — one `NewTransactionEntry` POS page: product search («Найдите товар по названию или артикулу…»), cart «Позиции», partner picker + projected «Баланс после продажи/поставки» card, warehouse «Склад»/«Склад приёмки», bulk-discount row, notes/attachments toggle, `TransactionSummaryCard` (totals → payment «Оплата» with wallet + amount + «Вся сумма» → overpayment disposition → immutability note → «Провести продажу»/«Провести поставку»), «Сохранить как шаблон», «Загрузить шаблон», keyboard hints.
+
+## Traps
+
+Module-specific; shared-checklist §6 still applies.
+
+| Observation | Why it's correct |
+| --- | --- |
+| Supply lines never warn or block on stock («Превышает остаток…» appears on Sale lines only) | supplies are stock-IN (R20 blocks stock-outs only) |
+| No payment-type or direction control in the POS payment section | guided flow — type fixed by context, direction derived (R13–R14) |
+| «Погасить долги» button inside POS totals on overpayment | R40 settle-other-debts opt-in; the standalone-payments DR-05 deferral does not apply to this guided flow |
+| Sale submit with zero payment interrupts with a dialog «Провести без оплаты?» → «Провести в долг» | deliberate friction before creating debt, not a validation failure |
+| Wallet options render «{тип} · баланс N UZS» exposing balances in the picker | designed tender affordance |
+| «Скачать» on detail → toast «… — раздел в разработке» | dev stub |
+| Sale and Supply numbers interleave in one sequence | DR-21 single series |
+| Product search shows «Нет в наличии» but still allows adding the product on Supply | stock-in needs no stock |
+
+## Happy path
+
+Run in doc order; later cases consume earlier data. Run-scoped set: products «QA-<MMDD> Товар П1» and «QA-<MMDD> Товар П2» (both sale 1 000 / supply 100), partner-supplier «QA-<MMDD> Поставщик П», partner-customers «QA-<MMDD> Покупатель» and «QA-<MMDD> Покупатель Б» (created in T-POS-35). Fixtures used: «QA Склад А», «QA Касса», «QA Категория», «QA Товар Упаковка».
+
+### T-POS-01 · Run-scoped setup [happy] ✍
+
+Pre: fixtures seeded.
+Steps: 1. Create product «QA-<MMDD> Товар П1»: category «QA Категория», SKU «QA-<MMDD>-P1», unit шт, supply price 100, sale price 1 000. 2. Create product «QA-<MMDD> Товар П2»: same category, SKU «QA-<MMDD>-P2», unit шт, supply price 100, sale price 1 000. 3. Create partners «QA-<MMDD> Поставщик П» (Поставщик, opening 0) and «QA-<MMDD> Покупатель» (Клиент, opening 0).
+Expect: products created with **no quantity/cost inputs** on the form (R22); product list stock 0 for both.
+
+### T-POS-02 · First supply seeds stock and WAC [happy] ✍
+
+Pre: T-POS-01.
+Steps: 1. `/supplies/new`: partner «QA-<MMDD> Поставщик П», «Склад приёмки» = «QA Склад А». 2. Add П1, qty 10, «Цена поставки за шт» 100. 3. Add П2, qty 10, «Цена поставки за шт» 100. 4. «Оплата»: wallet «QA Касса», «Вся сумма» (2 000). 5. «Провести поставку».
+Expect: success toast cites the document number — per DR-21/F19 it must render «№N»; the current string is «Поставка #{{number}} проведена» — if «#N» renders, report a Cosmetic defect (convention violation), the supply itself is fine. «QA Склад А» → Остатки: П1 qty 10, «Сред. себест.» 100; П2 qty 10, «Сред. себест.» 100 (#16); П1 product detail totalStock 10.
+
+### T-POS-03 · Second supply at a new price — WAC oracle [happy] ✍
+
+Pre: T-POS-02.
+Steps: 1. `/supplies/new`: same partner/warehouse, П1 × 10 @ 200 (2 000). 2. No payment → «Провести поставку» → dialog «Провести без оплаты?» (body names the amount and «нашим долгом перед поставщиком») → «Провести в долг».
+Expect: supply created, status «Не оплачено», payable 2 000 on the supplier (partner-POV display per [partners.md](partners.md)). Stock 20; **WAC = 150** on the warehouse row and product detail — (10×100 + 10×200)/20 (R18). No formula shown in the UI, tooltip only (#16).
+
+### T-POS-04 · Discount math on a credit sale [happy] ✍
+
+Pre: T-POS-03 (П1 stock 20, П2 stock 10).
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Покупатель», «Склад» = «QA Склад А». 2. Line 1: П1 qty 5, price 1 000, discount **fixed** 800. 3. Line 2: П2 qty 5, price 1 000, discount **10%**. 4. Read the line totals and the summary. 5. Zero payment → «Провести продажу» → «Провести в долг».
+Expect: line 1 «Итоговая цена» **4 200** — fixed is off the whole line, not per-unit (R37; math: 5 000 − 800). Line 2 → **4 500** (R37). Summary: «Подытог» 10 000 · «Скидка» 1 300 · «Итого» 8 700 — computed sum of line discounts, no transaction-level discount input anywhere (R38). Partner picker was empty until chosen (R39, #9). Sale lands «Не оплачено», stock П1 15 · П2 5.
+Known: the fixed-discount helper text reads «Фиксированная сумма за единицу» — it contradicts the actual whole-line math (verified in `transactionUtils.lineNet`); if the hint still says «за единицу», report a copy defect (clarity guideline; R37).
+
+### T-POS-05 · Fully-paid sale — no dialog, Closed [happy] ✍
+
+Pre: T-POS-04 (П1 stock 15).
+Steps: 1. `/sales/new`: «QA-<MMDD> Покупатель», П1 × 2 @ 1 000, no discount. 2. «Оплата»: «QA Касса», «Вся сумма» (2 000). 3. «Провести продажу».
+Expect: no «Провести без оплаты?» dialog (payment covers total); toast; list row «Оплачено»; detail financial card «Оплачено полностью», «Остаток» 0; «Платежи» section shows one generated payment. П1 stock 13.
+
+### T-POS-06 · Partial payment → «Частично» [happy] ✍
+
+Pre: T-POS-05 (П1 stock 13).
+Steps: 1. `/sales/new`: same partner, П1 × 3 @ 1 000 (3 000). 2. Pay 1 000 from «QA Касса». 3. Submit (dialog appears for the unpaid remainder only if implemented for partial — record which) → confirm.
+Expect: sale created; status «Частично» (PartiallyPaid); detail «Оплачено» 1 000, «Остаток» 2 000 — served figures (R12). П1 stock 10.
+
+### T-POS-07 · Overpayment: change default; settle-debts opt-in; advance gated [happy] ✍
+
+Pre: T-POS-06 — partner has open debt (8 700 + 2 000). П1 stock 10.
+Steps: 1. `/sales/new`: same partner, П1 × 2 @ 1 000 (2 000). 2. Pay 3 000 from «QA Касса» — leftover 1 000 appears. 3. Inspect the disposition controls. 4. Open «Погасить долги» → modal «Распределение платежа»: verify the partner's open transactions are listed with «Остаток» and an «Авто (по порядку)» auto-allocation button; allocate the 1 000 to the oldest (T-POS-04 sale). 5. «Провести платёж» → toast «Распределено по долгам · 1 000 UZS»; summary now shows a «Погашение долгов» row of −1 000 with a «№N» sub-row. 6. Submit.
+Expect: default disposition is «Сдача» (#5, R40); an «Аванс» toggle is **not** offered while other debt remains (R40, #6); settling is opt-in via the modal. After submit: the T-POS-04 sale's «Остаток» drops by 1 000 (8 700 → 7 700), its chip «Частично»; the new sale «Оплачено». П1 stock 8.
+
+### T-POS-08 · Package-unit entry [happy] ✍
+
+Pre: fixture «QA Товар Упаковка» (packaging size 12) with stock ≥ 24 in «QA Склад А» — if absent, first supply 3 packages/36 units via `/supplies/new` from partner «QA-<MMDD> Поставщик П», paid in full from «QA Касса».
+Steps: 1. Read and note the current «QA Товар Упаковка» stock on «QA Склад А»; then `/sales/new`: partner «QA-<MMDD> Покупатель», add «QA Товар Упаковка». 2. Check whether the line offers package-based quantity entry; if yes, enter 2 packages; if only base units, enter 24 and record the observation. 3. Submit paid in full from «QA Касса».
+Expect: stock decremented by exactly 24 base units (R21: package count × size); with package entry, the entered package count stays visible on the line and the detail. If no package entry exists anywhere on the line, report an R21 gap observation (canon expects package-count entry retained on the line) — not a stock-math failure if base units still move correctly.
+
+### T-POS-09 · Save as template; load fills current prices [happy] ✍
+
+Pre: T-POS-04 partner exists.
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Покупатель», П1 × 2. 2. «Сохранить как шаблон» → name «QA-<MMDD> Шаблон» → «Сохранить шаблон». 3. Leave the page (dialog «Несохранённые изменения» → «Уйти со страницы»). 4. Fresh `/sales/new`: same partner → «Загрузить шаблон» → pick it.
+Expect: template save requires partner + lines («Сначала выберите партнёра», «Добавьте хотя бы одну позицию» when missing); load toast «Шаблон «QA-<MMDD> Шаблон» загружён»; lines fill with the product's **current** sale price (templates store products, never prices — Domain model); the menu is partner-scoped («У этого партнёра нет шаблонов» for others). Leave without submitting.
+Known: price-change proof is blocked by F1 (product edit crash) — assert current-price fill only.
+
+### T-POS-10 · List filters, search, export [happy]
+
+Pre: T-POS-02…07 data.
+Steps: 1. `/sales`: status filter «Частично». 2. Reset; search the T-POS-04 document number (bare digits). 3. Search «Покупатель». 4. Period «Последние 7 дней». 5. «Экспорт CSV» with search active.
+Expect: each filter narrows correctly; number search finds the sale; CSV contains exactly the filtered rows (#11); empty combination → «Ничего не найдено» + mode-specific hint text.
+
+## Edge & negative
+
+### T-POS-30 · Submit without partner / without lines [negative]
+
+Steps: 1. `/sales/new`: add a line, no partner → «Провести продажу». 2. Clear cart via «Очистить»; pick a partner, no lines → submit.
+Expect: 1 → inline «Выберите партнёра» on the picker (R39, #9; DR-24 — no banner); 2 → cart error state «Добавьте хотя бы одну позицию». Button enabled throughout (#7). No POST fires either time.
+
+### T-POS-31 · Over-stock sale blocked with numbers [negative]
+
+Pre: П1 stock as left by happy path (finite, known — read it first on «QA Склад А»).
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Покупатель», П1 qty = stock + 50. 2. Observe the line. 3. Submit.
+Expect: live line hint «Превышает остаток · доступно N шт»; on submit the line errors «Недостаточно товара: доступно N шт» + summary error «Исправьте количество в выделенных позициях»; **no POST** (client hard-block, R20/DR-10). Input itself accepts any number (#7 — block reports, never disables). Fix the qty to 1 and abandon the page (unsaved dialog).
+
+### T-POS-32 · Fixed discount above line gross clamps to zero [edge]
+
+Steps: 1. `/sales/new`: any partner, П1 qty 5 @ 1 000, fixed discount 6 000. 2. Read the line total. 3. Leave without submitting (discard dialog).
+Expect: «Итоговая цена» 0 — clamped to line gross, never negative (R37). No submit — display-only check.
+
+### T-POS-33 · Bulk percent overwrites per-line discounts [edge]
+
+Steps: 1. `/sales/new`: a П1 line with fixed 800 and a П2 line with 10%. 2. «Применить скидку ко всем»: 5% → «Применить». 3. Inspect both lines. 4. Leave (discard).
+Expect: both lines now carry exactly 5% («−5% на все позиции» chip) — the fixed 800 is gone, nothing stacked (R38). Bulk input is percent-only by design.
+
+### T-POS-34 · Supply tender exceeding wallet balance blocked [negative]
+
+Pre: read «QA Касса» balance from the wallet option label («Наличные · баланс N UZS»).
+Steps: 1. `/supplies/new`: supplier partner, П1 × 1 @ 100. 2. «Оплата» from «QA Касса», amount = balance + 1 000. 3. Submit.
+Expect: inline «Доступно только N UZS — нельзя списать больше остатка кассы.» (DR-25); no POST. This is the first live verification of the POS-Supply overdraft guard (shipped code-only in PR #72) — state the outcome explicitly in the report. Sales (income direction) never show this guard.
+
+### T-POS-35 · Credit sale to a partner holding an advance [edge] ✍
+
+Pre: create partner «QA-<MMDD> Покупатель Б» (Клиент, opening 0) — zero debt, so the deposit can become an advance (R40; against a partner with open debt it would settle the oldest sale instead, corrupting T-POS-60's oracle). Give «Покупатель Б» an advance: payments modal → «Депозит», 500 from «QA Касса» ([payments.md](payments.md) mechanics).
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Покупатель Б», П1 × 1 @ 1 000, zero payment. 2. Observe the summary/payment area before submitting. 3. Abandon (do not submit).
+Expect: i18n carries an unused `payment.mustUseBalanceWarning` string («У партнёра есть доступный баланс…») that no component renders — do not assert it; no advance-balance warning currently surfaces in the POS. Record exactly what (if anything) surfaces the partner's advance and whether submit is possible; canon does not specify the enforcement — report behavior as an observation, not a new defect.
+
+## Reconciliation
+
+### T-POS-60 · Detail arithmetic ↔ list ↔ served totals [reconcile]
+
+Pre: T-POS-04 sale.
+Steps: open its detail; compare with its `/sales` row and `GET /api/transactions/{id}`.
+Expect: «Подытог» 10 000 − «Скидка по позициям» 1 300 = «Итого» 8 700; list «Сумма» = 8 700; served `totalDue`/`totalPaid`/`remaining` match the financial card digit-for-digit (server-computed, R12); «Остаток» = Итого − Оплачено after T-POS-07's settlement (7 700).
+
+### T-POS-61 · Stock chain ↔ product movements [reconcile]
+
+Steps: 1. «QA Склад А» → Остатки: П1 and П2 rows. 2. Product П1 detail → Движения; repeat for П2. 3. Compare quantities and «Сред. себест.».
+Expect: warehouse qty = product totalStock (single-warehouse products); П1 movements list the full run chain +10 +10 −5 −2 −3 −2 with signed quantities and running balanceAfter ending at 8; П2 movements +10 −5 ending at 5; WAC 150 (П1) and 100 (П2) everywhere until any later stock-in (R17–R18; the run created no other stock-in events — see business-rules Domain model → Stock-in events).
+
+### T-POS-62 · POS-generated payments ↔ payments list ↔ wallet [reconcile]
+
+Steps: 1. `/payments`: search «Покупатель» and «Поставщик П». 2. Open «QA Касса» detail → Операции.
+Expect: every paid POS case above produced exactly one «Оплата» payment (T-POS-02: 2 000 expense; T-POS-05: 2 000 income; T-POS-06: 1 000; T-POS-07: 3 000; T-POS-08: package sale — plus, additionally, the conditional top-up supply payment when T-POS-08's fallback supply ran) — amounts, dates and directions match; wallet operations contain the same amounts with consistent running «Баланс после» (R8, R15).
+
+### T-POS-63 · One number series across directions [reconcile]
+
+Steps: list the run's document numbers (sales + supplies) in creation order.
+Expect: strictly increasing single sequence — supplies do not reset or fork the series (DR-21); every rendering is «№N» with no Latin prefix.

--- a/docs/testing/modules/wallets.md
+++ b/docs/testing/modules/wallets.md
@@ -1,0 +1,141 @@
+# Wallets — test cases (T-WAL)
+
+Deep pass over the Wallets module («Касса»): CRUD-minus-delete, opening-balance event, inter-wallet transfers, the Операции/Переводы ledgers, advances math, archive. See [README](../README.md) · [shared-checklist](../shared-checklist.md) · [fixtures](../fixtures.md) · canon: business-rules §C (R15–R16), R11–R12, R31 · contract `backend-contracts/wallets.md`.
+
+## Surfaces
+
+- `/wallets` — list: `WalletsTable` (name · type · Баланс · Авансы партнёров · Наши средства · ⋮), `WalletSummaryStrip` (Общий баланс / Наши средства / Авансы партнёров), search, segmented «Активные | Архив», «Экспорт», «Новая касса».
+- `/wallets/:id` — detail (stacked, no rail): header (name + type badge, meta «Начальный остаток: … UZS · создана …»), primary «Новый перевод», ⋮ (edit/archive); three stat cards «Баланс» / «Наши средства» / «Авансы»; tabs Операции / Переводы with count pills.
+- Modals: `WalletFormModal` (create/rename), `WalletTransferModal` (from → to, amount, note), `WalletTransferDetailModal` (read-only), archive/restore confirms.
+
+## Traps
+
+Module-specific designed behavior — never report these (shared-checklist §6 has the rest):
+
+| Observation | Why it's correct |
+| --- | --- |
+| **No delete affordance anywhere on wallets** — list ⋮ and detail ⋮ offer edit + archive/restore only | Known divergence, not designed-correct: archive-only is the *shipped interim* behavior (repo-state Wallets; archive dialog copy) and diverges from DR-20/#19 — delete stays visible, reference-gated via served `isDeletable`; the FE affordance "follows" (not yet built). Observe per T-WAL-38; don't report as a NEW defect |
+| A Депозит raises «Баланс» AND «Авансы» while «Наши средства» stays flat | R11 — an advance is a partner's claim on cash sitting in the wallet |
+| After an overpayment-into-advance, «Наши средства» grows by less than the money that came in | R12 — only the settled part is ours (worked example 1) |
+| Operation kind labels mirror payment-type vocabulary: kind `Expense` renders «Общий», `Payment` renders «Оплата» | deliberate i18n mapping (`wallet.operation.*`), #17 wallet clause |
+| Clicking a transfer row opens a modal; clicking a payment row navigates to `/payments/:id` | designed split — transfers have no routed detail page |
+| An archived wallet is absent from the transfer and payment-source pickers while its money stays in the strip | R30/R31, #13 — hidden from pickers, not from value |
+| Transfer modal opened from a wallet detail pre-selects that wallet as source | designed default |
+
+## Happy path
+
+Run in order — later cases consume earlier data. All numeric oracles use the run-scoped wallets created here; stable fixture wallets are picker material only (fixtures.md).
+
+### T-WAL-01 · Create Cash wallet — opening balance is an event [happy] ✍
+Pre: none.
+Steps: 1. `/wallets` → «Новая касса». 2. Name «QA-<MMDD> Касса А», type «Наличные», opening 500 000. 3. Save.
+Expect: toast «Касса «QA-<MMDD> Касса А» создана»; row: Баланс 500 000 · Авансы 0 · Наши средства 500 000 (R15). Open detail: meta line «Начальный остаток: 500 000 UZS»; Операции has exactly one row — «Начальный остаток» · «Приход» · 500 000 · Баланс после 500 000 (R16 — an auditable event, not a raw number). No raw balance input exists anywhere on the page.
+
+### T-WAL-02 · Create Bank wallet [happy] ✍
+Pre: none.
+Steps: create «QA-<MMDD> Касса Б», type «Банк», opening 200 000.
+Expect: as T-WAL-01 with 200 000; type badge «Банк» on row and detail (no raw `Bank`).
+
+### T-WAL-03 · Stat cards are the served figures [happy]
+Pre: T-WAL-01.
+Steps: open Касса А detail; capture the network `GET /api/wallets/{id}` response.
+Expect: cards «Баланс»/«Наши средства»/«Авансы» equal served `balance`/`ourMoney`/`advancesHeld` exactly — no client math (R12, hard rule 8); on the served values `ourMoney = balance − advancesHeld` (R12).
+
+### T-WAL-04 · Edit is rename-only [happy]
+Pre: T-WAL-01.
+Steps: 1. Касса А → ⋮ → «Редактировать». 2. Inspect the form. 3. Rename to «QA-<MMDD> Касса А2», save. 4. Rename back.
+Expect: title «Редактировать кассу», subtitle «Тип и начальный остаток изменить нельзя»; type and opening render as read-only locked fields tagged «нельзя изменить» / «записан при создании» — no editable input for either (R16); toast «Изменения сохранены»; all three money figures unchanged by the rename.
+
+### T-WAL-05 · Inter-wallet transfer updates both wallets, immutable [happy] ✍
+Pre: T-WAL-01, T-WAL-02. Record strip «Общий баланс» first.
+Steps: 1. Касса А detail → «Новый перевод» (source pre-set = А). 2. To: Касса Б, amount 150 000, note «QA перевод». 3. «Перевести».
+Expect: toast «Перевод проведён: QA-<MMDD> Касса А → QA-<MMDD> Касса Б». А: Баланс 350 000; Операции top row «Перевод» · «Расход» · 150 000 · Баланс после 350 000; Переводы tab shows the row (Из кассы А → В кассу Б). Б detail: Баланс 350 000; same transfer in its Переводы; Операции row «Приход» · 150 000 · Баланс после 350 000. Row click opens the read-only detail modal with «Перевод записан окончательно.» and zero edit/delete affordances (R1, R16). Strip «Общий баланс» unchanged (internal move).
+
+### T-WAL-06 · Deposit raises balance AND advances; «Наши средства» flat [happy] ✍
+Pre: T-WAL-05 (Б at 350 000). Create partner «QA-<MMDD> Партнёр Кас» (Клиент, opening 0) via `/partners`.
+Steps: `/payments` → create payment → type «Депозит», partner «QA-<MMDD> Партнёр Кас», wallet Касса Б, amount 100 000 → submit.
+Expect: Б cards: Баланс 450 000 · Авансы 100 000 · Наши средства 350 000 (R11, R12); Операции top row «Депозит» · «Приход» · 100 000 · Баланс после 450 000. Strip deltas vs T-WAL-05 end: Общий баланс +100 000, Авансы партнёров +100 000, Наши средства ±0.
+
+### T-WAL-07 · Overpay-into-advance: balance +full tender, our money +settled part only [happy] ✍
+Pre: T-WAL-05 (А at 350 000). Create partner «QA-<MMDD> Партнёр Кас2» (Клиент, opening 0). Needs ≥1 unit «QA Товар Штучный» in stock — if the sale hard-blocks (R20), add stock via «Начальный остаток» on QA Склад А, else SKIP.
+Steps: 1. `/sales/new`: partner «QA-<MMDD> Партнёр Кас2», 1 × «QA Товар Штучный» (15 000), warehouse QA Склад А, payment 25 000 into Касса А, excess disposition → «Аванс» (opt-in, #5, R40). 2. Submit. 3. Open Касса А detail.
+Expect: one Wallet source 25 000 balancing settlement 15 000 + advance 10 000 (R8–R10, worked example 1). А cards: Баланс 375 000 (+25 000 — full tender, R15) · Авансы 10 000 · Наши средства 365 000 (+15 000 — only the settled part, R11–R12). Операции top row «Оплата» · «Приход» · 25 000 · Баланс после 375 000.
+
+### T-WAL-08 · Операции ledger: localization, order, running balance, links [happy]
+Pre: T-WAL-07 (А has 3 operations).
+Steps: on А's Операции tab: read rows; apply direction filter «Расход»; search the partner name from T-WAL-07; click the «Платёж» cell link.
+Expect: newest-first default (#21): «Оплата» 375 000 → «Перевод» 350 000 → «Начальный остаток» 500 000 in «Баланс после» — each row's balanceAfter = previous (older) balanceAfter ± amount; kinds localized, no raw `Opening`/`Payment` (#17); direction pills «Приход»/«Расход», amounts unsigned (#4); filter «Расход» leaves only the transfer row; search leaves only the payment row; payment reference renders «№N» (DR-21) and routes to `/payments/:id`. Party cell is plain text — not clickable (Known below).
+Known: F10 — direction narrowed to In/Out (if the backend serves Income/Expense every row shows red «Расход» — report KNOWN); op `partnerId` unmodeled, party not clickable (WAL-7). If the «Платёж» cell shows bare digits without «№», report a DR-21 defect — `WalletOperationsTab.tsx:121` renders the raw served number and was not in the F19 sweep.
+
+## Edge & negative
+
+### T-WAL-30 · Duplicate name rejected [negative]
+Pre: T-WAL-01.
+Steps: «Новая касса» → name exactly «QA-<MMDD> Касса А», any type, opening 0 → save.
+Expect: server 400 (contract: name unique in org) → toast «Не удалось создать кассу»; modal stays open; no row added. No inline duplicate message exists — toast only.
+
+### T-WAL-31 · Name length bounds inline [negative]
+Steps: in the create modal try name of 1 char → save; then a 251-char name → save.
+Expect: inline «Введите название кассы (минимум 2 символа).» / «Название не должно превышать 250 символов.»; save button stays enabled throughout (hard rule 5, #7); no top-of-form banner (DR-24, #18). Close via discard confirm.
+
+### T-WAL-32 · Opening balance cannot go negative [negative]
+Steps: in the create modal type `-1000` into «Начальный баланс».
+Expect: the minus never appears — `MoneyField` is digits-only, value reads 1 000; opening 0 (empty till) is accepted (contract: `openingBalance` ≥ 0).
+
+### T-WAL-33 · Transfer from ≠ to enforced [negative]
+Steps: open the transfer modal; open the «В кассу» dropdown while «Из кассы» = Касса А; then the reverse.
+Expect: each picker shows the counterpart's selection greyed/disabled — the same wallet cannot occupy both sides (contract: `toWalletId` ≠ `fromWalletId`); fallback inline message «Касса-получатель должна отличаться от источника».
+
+### T-WAL-34 · Over-balance transfer blocked with available-vs-requested detail [negative]
+Pre: T-WAL-07 (А at 375 000).
+Steps: transfer modal from А: 1. enter amount 375 001 → «Перевести». 2. Click «Перевести всё». 3. Cancel via discard confirm (do not submit).
+Expect: «Доступно:» hint shows 375 000; at 375 001 inline «Доступно только 375 000 UZS — нельзя перевести больше остатка.» and the click issues **no** POST (check network) — hard-block per contract/DR-25; «Перевести всё» sets exactly 375 000 and the error clears.
+Known: F13 — the guard uses the raw balance, so a **negatively**-balanced wallet blocks ALL its transfers (latent; only reproducible with an overdrawn wallet — report KNOWN, not new).
+
+### T-WAL-35 · Transfer amount required [negative]
+Steps: transfer modal, leave amount 0 (destination valid) → «Перевести».
+Expect: inline «Введите сумму перевода»; no request sent; button never disabled (#7).
+
+### T-WAL-36 · Archive with balance — strip totals unchanged [edge]
+Pre: T-WAL-06 (Б at 450 000 with 100 000 advances). Record all three strip values.
+Steps: 1. `/wallets` → Касса Б ⋮ → «Архивировать». 2. Confirm dialog. 3. Re-read the strip; switch segments.
+Expect: dialog title «Архивировать кассу «QA-<MMDD> Касса Б»?», body states archive-not-delete and that the balance keeps counting; row leaves «Активные», appears under «Архив» with the «Архив» badge (#13); **all three strip totals are identical before/after** (R31 — archived money still counts).
+
+### T-WAL-37 · Archived wallet: affordances + picker exclusion, then restore [edge]
+Pre: T-WAL-36 (Б archived).
+Steps: 1. Open Б's detail. 2. From А open the transfer modal and both pickers. 3. Open the payment-create wallet picker. 4. Back on Б detail: «Восстановить».
+Expect: Б detail shows banner «Касса в архиве.», a single primary «Восстановить», no ⋮/edit/«Новый перевод» (#2); Б absent from both transfer pickers and from the payment wallet picker (R30, #13); its historical rows (T-WAL-05 transfer in А's Переводы) still resolve by name (R30). Restore → toast «Касса «QA-<MMDD> Касса Б» восстановлена», row back in «Активные», figures intact (450 000 / 100 000 / 350 000).
+
+### T-WAL-38 · No delete affordance anywhere [negative]
+Pre: T-WAL-36.
+Steps: inspect the list ⋮ of an active and an archived wallet, and the detail ⋮. Perform the archived-wallet ⋮ inspection on Касса Б while it is archived — i.e. run this check between T-WAL-36 and T-WAL-37 — or re-archive Касса Б, inspect its list ⋮, and restore it afterwards.
+Expect: only edit + archive (or restore) — no delete item anywhere; the archive dialog body states «Кассы нельзя удалить — только архивировать.» (repo-state Wallets — shipped behavior). Known: diverges from DR-20/#19 (delete stays visible, reference-gated; FE affordance pending) — report as KNOWN, and flag that the divergence needs an F-item in frontend-gaps.md or a decision-log ruling. If a delete item appears, DR-20 FE work has landed — re-check this case and the archive-dialog copy «Кассы нельзя удалить — только архивировать.», which also contradicts DR-20/R32.
+
+### T-WAL-39 · Bad deep-link [negative]
+Steps: navigate to `/wallets/9999999`.
+Expect: «Касса не найдена.» rendered, no crash/blank; network shows the 404.
+
+## Reconciliation
+
+### T-WAL-60 · Balance card ↔ newest operation's running balance [reconcile]
+Pre: T-WAL-07, T-WAL-37 done.
+Steps: for both run-scoped wallets compare the «Баланс» stat card to the top (newest) Операции row's «Баланс после».
+Expect: equal on both — А 375 000, Б 450 000 (R15; the served running ledger ends at the served balance).
+
+### T-WAL-61 · List row ↔ detail cards ↔ API [reconcile]
+Steps: for Касса А read the list row (Баланс/Авансы/Наши средства), the three detail cards, and the `GET /api/wallets/{id}` body.
+Expect: all three surfaces show 375 000 / 10 000 / 365 000, matching the served fields digit-for-digit; `ourMoney = balance − advancesHeld` holds on the served values (R12).
+
+### T-WAL-62 · Summary strip ↔ sum of all rows, both segments [reconcile]
+Steps: set the pager to 50; sum Баланс, Наши средства, Авансы партнёров across ALL rows of «Активные» plus «Архив».
+Expect: the three sums equal the strip's «Общий баланс» / «Наши средства» / «Авансы партнёров» exactly (R31 — archived rows included in the totals).
+
+### T-WAL-63 · Transfer double-entry across both wallets [reconcile]
+Pre: T-WAL-05.
+Steps: open the Переводы tab of А and of Б; open the transfer's detail modal from each side.
+Expect: the same transfer row on both sides — identical date, amount 150 000, note, Из кассы/В кассу names; in the Операции ledgers it appears once per wallet with opposite directions («Расход» on А, «Приход» on Б) and equal amounts (atomic double move per contract; R1 immutable).
+
+### T-WAL-64 · Wallet operation ↔ payment detail [reconcile]
+Pre: T-WAL-07.
+Steps: from А's «Оплата» operation row follow the «Платёж» link to `/payments/:id`.
+Expect: payment detail's Касса source line = Касса А, 25 000 — same wallet and amount as the operation row; Распределение shows settlement 15 000 + advance 10 000, and the advance line equals А's «Авансы» card (R8, R11).

--- a/docs/testing/shared-checklist.md
+++ b/docs/testing/shared-checklist.md
@@ -1,0 +1,75 @@
+# Shared checklist — cross-cutting assertions
+
+Applied to **every screen** the run visits, in every tier. Module docs never repeat these — they only add module-specific cases. Citations: `R n` = `../../../Ombor.Docs/business-rules.md` rule n · `#n` = `../../../Ombor.Docs/ui-patterns.md` pattern n · `DR-n` = `../../../Ombor.Docs/decision-log.md` · `F n` = [../frontend-gaps.md](../frontend-gaps.md).
+
+## 1. Forbidden-affordance scan (any hit = defect)
+
+| Violation                                                                                                     | Rule            |
+| ------------------------------------------------------------------------------------------------------------- | --------------- |
+| Edit or delete affordance on a transaction, payment, payroll, stock adjustment, or transfer — rows, detail pages, kebab menus | R1, #8          |
+| Disabled/greyed submit or action button (validation must run on submit and report inline)                      | hard rule 5, #7 |
+| Breadcrumbs anywhere                                                                                            | #20f, DR-04     |
+| Side pane / drawer form — exception: legacy Products & Categories, pending rebuild                              | #1, #3          |
+| Currency selector, exchange rate, any non-UZS currency artifact                                                 | R33             |
+| «Сумма, UZS»-style column headers (currency unit only via the shared `UzsUnit` component, never in headers)     | conventions     |
+| `+`/`−` signs on balance figures where direction is conveyed by color/label/chip (see POV trap in §5)           | #4              |
+| Raw enum value leaking to UI: `Both`, `Sale`, `Open`, `Cash`…                                                   | #15, i18n       |
+| Raw i18n key visible (literal `partner.table.name` on screen)                                                   | conventions     |
+| Latin document prefixes (`ORD-42`, `PAY-7`) — document numbers render only as «№42»                             | DR-21           |
+| Hardcoded/English UI strings — known exceptions listed under F16                                                | hard rule 2     |
+
+## 2. Every list page
+
+- `PageHeader`: h1 title; dataset actions on the title row (primary create, «Экспорт»); view-shaping controls (search, filters, tabs, archive toggle) on the row below (#11).
+- `DataTable` chrome: header/footer bands, zebra rows, 52px height, tabular numerals; column order № → date → primary entity → type/status chip → descriptive → money (right-aligned) → `⋮` (#21).
+- Sorting: columns sortable by default (not actions/long-text); default sort date-desc on event feeds, name-asc on master data (#21).
+- Pager 10/25/50, ru-localized (#21). All lists fetch-all and page client-side — sluggishness on large data is **F14 (known)**.
+- Row actions only inside the `⋮` `ActionMenu` — inline icon buttons are a defect (#21). Archived rows carry the «Архив» badge.
+- Archive control (Products, Partners, Wallets, Warehouses only): segmented «Активные | Архив» that **swaps** the dataset — archived rows never mixed into the active list (#13).
+- «Экспорт» downloads a client-side CSV of the **current filtered view**.
+- Empty table shows hardcoded «Нет записей» — **F16 (known)**, not a new find.
+
+## 3. Every detail page
+
+- Routed URL; deep-link and browser refresh both work (#1). Back button returns to the list (history-back with list fallback); no breadcrumb (#20a/20f).
+- Title = entity name only, or «№N» for numbered events — no chips, no meta line in the title (#20e). Edit/archive/restore only in the `⋮` kebab (#2); at most one `primaryAction` header button (child-event creation).
+- Tabs are underline-style with count pills (#20b).
+- Layout: right-rail **only** on Product, Order, Transaction, Payment; stacked everywhere else (#20g, DR-01) — a missing rail on Partner/Wallet/Warehouse/Employee is correct.
+- Detail-embedded tables use the warm `detailTableChrome` (header band + total band or pager), not the list `DataTable` (#20d); sortable via `DetailSortHeader`; tab-level filters live **inside** the table widget (#14).
+
+## 4. Every form (modal)
+
+- Centered modal, never a drawer (#3).
+- Submit always enabled; invalid submit → inline per-field errors with autofocus to the first error; **no top-of-form error banner** (DR-24, #18). Server/submit failure → notistack toast; a silent failure is a defect.
+- Closing a dirty form asks to confirm discarding (useDirtyClose). Enter / Ctrl+Enter submits (XC-11).
+- Money inputs group thousands live while typing (`MoneyField`); phone inputs render «+998 XX XXX XX XX» with a fixed prefix.
+- Required-field labels carry an error-colored asterisk.
+
+## 5. Formats & display (any screen)
+
+- Money: «1 250 000» — space-grouped, no symbol, tabular figures (`formatCurrency`).
+- Dates: `DD.MM.YYYY`; event timestamps «07.07.2026 16:33» (space separator).
+- Document/entity numbers: «№N» via `formatEntityId`. Transactions share **one** number series across Sale/Supply/refunds (DR-21) — a Sale «№5» followed by a Supply «№6» is correct.
+- Balances: color + a direction **word**, never a bare signed number (#4). Implemented vocabulary: owner-POV buckets «Нам должны» / «Мы должны» on Debts, Dashboard, and the POS balance card («Без долга» at zero); partner surfaces render partner-POV **signed** figures — a documented divergence from #4, see `modules/partners.md` Traps before judging signs/colors there. The literal canon strings «Вам должны…»/«Нет долга» exist nowhere in the app — do not assert them.
+- PaymentType labels: Оплата · Депозит · Вывод · Зарплата · Общий (#17). PartnerType `Both` → «Клиент + Поставщик» (#15).
+- Chips: Sale=teal, Supply=saffron, refunds outlined; status Open=info, PartiallyPaid=warning, Overdue=error, Closed=success; Приход=green / Расход=red pills with unsigned amounts. Green/red on a *number* is reserved for money figures (#4); chips may use the full semantic palette.
+
+## 6. Traps — designed behavior that looks like a bug (never report these)
+
+| Observation                                                                                   | Why it's correct                                  |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| No edit/delete on transactions, payments, payroll, adjustments, transfers                       | R1 — corrections are counter-events               |
+| Delete visible on a referenced Product/Partner/Wallet/Warehouse; clicking explains and offers archive | DR-20, #19 — served `isDeletable` gates the outcome, not the button |
+| POS partner picker starts empty; sale refuses to submit without a partner                       | R39, #9 — no walk-in partner by design            |
+| No «оплатить долги» button on partner page; standalone-payment allocation ordering imperfect    | DR-05 — deferred to v2                            |
+| One number series shared by Sales and Supplies                                                  | DR-21                                             |
+| Archived wallet with balance / warehouse with stock still counted in totals                     | R31 — hidden from pickers, not from value         |
+| No quantity/cost inputs on the product form                                                     | R22 — stock enters only via opening stock / supply |
+| Integer-only quantity inputs                                                                    | DR-12/DR-22 — fractional slice pending            |
+| No receipt printing, no Reports module, no roles/permissions UI                                 | DR-09 · v2 · R35/DR-07                            |
+| «Отчёты» absent from sidebar; no section-label headings in nav                                  | #10                                               |
+| Global search field and notifications bell do nothing                                           | known stubs (see smoke.md)                        |
+| Zod validation messages don't re-translate on live language switch                              | documented limitation (conventions §i18n)         |
+| Starter partner/wallet/warehouse/category fully editable and deletable                          | R42 — ordinary entities, no system flag           |
+| Wallet «Наши средства» smaller than its balance                                                 | R12 — advances held are someone else's claim      |
+| «Все даты» filters / static pager rows absent compared to prototypes                            | #12 — inert prototype affordances omitted         |

--- a/docs/testing/smoke.md
+++ b/docs/testing/smoke.md
@@ -1,0 +1,102 @@
+# Smoke suite (T1)
+
+Read-mostly pass over the whole app: every route renders, navigation is complete, and each screen passes a [shared-checklist](shared-checklist.md) spot-check. No permanent events are created. Target: 30–45 min. Run [environment.md](environment.md) hygiene assertions throughout.
+
+Result vocabulary and reporting: see [README.md](README.md).
+
+## Shell & navigation
+
+### T-SMK-01 · Sidebar structure [happy]
+
+Expect exactly, top to bottom: Главное · Финансы (Платежи, Долги, Касса) · Транзакции (Партнёры, Заказы, Продажи, Поставки, Шаблоны) · Кадры (Сотрудники) · Каталог (Товары, Категории) · Склад (Склады, Корректировки, Перемещения); footer: Настройки, Выход. No section-label headings, no «Отчёты» (#10). Collapse/expand toggle works.
+
+### T-SMK-02 · Topbar [happy]
+
+- «Создать» menu → Продажа `/sales/new` · Поставка `/supplies/new` · Заказ `/orders/new` · Оплата `/payments/new` (placeholder page — known stub).
+- Global search field is a visual stub (known); notifications bell opens «Нет уведомлений» (known stub); language menu present; avatar menu shows full name + Выход.
+
+### T-SMK-03 · Auth guards [happy]
+
+Logged in, navigate to `/login` → redirected to `/`. Unknown URL (e.g. `/nope`) → NotFoundPage inside the app layout.
+
+### T-SMK-04 · Placeholders render, don't crash [happy]
+
+`/activity-log` (known U1) and `/payments/new` render PlaceholderPage with app chrome; console stays clean.
+
+## Route render pass
+
+For each route: page renders with correct h1/title, no console errors, no failed requests, and a §1 forbidden-affordance scan from the shared checklist. Additional per-route assertions:
+
+### T-SMK-10 · `/` Dashboard [happy]
+
+Period control (Сегодня/Неделя/Месяц, default Месяц); 4 KPI cards render numbers (not NaN/«не число»); charts, aging panel, top-debtors, recent-transactions table render. Known crash-risk F5 — an unknown transaction status crashing the table is KNOWN.
+
+### T-SMK-11 · `/products` and `/products/:id` [happy]
+
+List renders with archive toggle; open one product detail (tabs Overview/Транзакции/Движения + right rail). **Do not test edit** — F1 edit crash is a known Blocker. Legacy side-pane layout is known pending rebuild.
+
+### T-SMK-12 · `/categories` [happy]
+
+List renders; legacy module — layout deviations from shared checklist §2 are known pending rebuild; note only crashes/errors.
+
+### T-SMK-13 · `/warehouses` and `/warehouses/:id` [happy]
+
+Summary strip; detail with Остатки/Движения tabs, warm table chrome (#20d), stacked layout (no rail).
+
+### T-SMK-14 · `/adjustments` [happy]
+
+List with expand-row detail; no edit/delete anywhere (R1); direction chips.
+
+### T-SMK-15 · `/transfers` [happy]
+
+List renders; row opens detail modal (no route — correct); no edit/delete (R1).
+
+### T-SMK-16 · `/partners` and `/partners/:id` [happy]
+
+Summary strip; detail: balance card + Журнал/Транзакции/Платежи tabs with count pills, stacked layout. Deep link `/partners/:id?tab=transactions&status=open` lands on the filtered tab.
+
+### T-SMK-17 · `/orders` and `/orders/:id` [happy]
+
+Status tabs with live counts; detail: stepper, positions card, right rail. Order detail of a Delivered order links to its Sale.
+
+### T-SMK-18 · `/sales`, `/sales/:id`, `/supplies`, `/supplies/:id` [happy]
+
+Shared module — both directions render; refund rows show negative amounts and «Возврат к №N»; detail has right rail; no edit/delete (R1). Attachment display known-broken (F7).
+
+### T-SMK-19 · `/sales/new` and `/supplies/new` [happy]
+
+POS page renders: product search, empty cart, partner picker **empty by default** (R39), wallet/warehouse pickers, keyboard hints. Leave without submitting.
+
+### T-SMK-20 · `/templates` [happy]
+
+List with expand rows; «Использован» column shows «—» (known — `lastUsedAt` unserved).
+
+### T-SMK-21 · `/payments` and `/payments/:id` [happy]
+
+Summary strip; type column «Тип операции» with real localized types (#17); detail shows Касса + Распределение blocks; no edit/delete (R1). Unknown allocation types crashing is KNOWN (F9).
+
+### T-SMK-22 · `/debts` [happy]
+
+4 summary cards (3 clickable), По партнёрам/По транзакциям tabs, aging buckets; row drill-down navigates to partner detail debt view.
+
+### T-SMK-23 · `/wallets` and `/wallets/:id` [happy]
+
+Summary strip; detail: 3 stat cards («Баланс», «Авансы», «Наши средства»), Операции/Переводы tabs; «Наши средства» ≤ «Баланс» is correct (R12).
+
+### T-SMK-24 · `/employees` and `/employees/:id` [happy]
+
+List; detail with payroll history (empty state acceptable); terminate/restore affordances only via kebab.
+
+### T-SMK-25 · `/settings` [happy]
+
+Sections: Организация, Язык, Валюта (locked UZS, read-only — correct), Пользователи (invite/deactivate/reactivate; no delete — R41). Cosmetic «Администратор» chips are known-correct (no roles, DR-07).
+
+## Cross-screen spot checks
+
+### T-SMK-30 · Format sampling [happy]
+
+On any three money-bearing screens: amounts «1 250 000», dates `DD.MM.YYYY`, timestamps «07.07.2026 16:33», numbers «№N», no «Сумма, UZS» headers (shared checklist §5).
+
+### T-SMK-31 · Hygiene sweep [happy]
+
+After the full pass: console has zero errors; network log has no unexpected 4xx/5xx and zero sentry/posthog requests ([environment.md](environment.md)).

--- a/src/components/partner/Form/PartnerFormModal.tsx
+++ b/src/components/partner/Form/PartnerFormModal.tsx
@@ -487,16 +487,6 @@ const PartnerFormModal: React.FC<PartnerFormModalProps> = ({
 											</Box>
 										)}
 									/>
-									<Typography
-										sx={{
-											fontSize: 12,
-											fontWeight: 600,
-											color: "text.secondary",
-											lineHeight: 1.45,
-										}}
-									>
-										{t("partner.form.openingHint")}
-									</Typography>
 									{isSubmitted && errors.openingAmount?.message && (
 										<Typography sx={{ fontSize: 12, color: "error.main" }}>
 											{errors.openingAmount.message}

--- a/src/components/product/Form/Fields/ProductCoreFields.tsx
+++ b/src/components/product/Form/Fields/ProductCoreFields.tsx
@@ -28,7 +28,7 @@ export interface ProductFormCoreFieldsProps {
 	onGenerateSku?: () => void;
 }
 
-const MEASUREMENTS = ["Gram", "Kilogram", "Ton", "Piece", "Box", "Unit", "None"] as const;
+const MEASUREMENTS = ["Gram", "Kilogram", "Ton", "Piece", "Box", "None"] as const;
 const TYPES: ProductType[] = ["Sale", "Supply", "All"];
 
 const uzsSuffix = {

--- a/src/hooks/product/useProductForm.ts
+++ b/src/hooks/product/useProductForm.ts
@@ -51,7 +51,7 @@ export interface UseProductFormResult {
 const DEFAULT_VALUES: ProductFormInputs = {
 	name: "",
 	categoryId: null,
-	measurement: "Unit",
+	measurement: "Piece",
 	type: "All",
 	sku: "",
 	description: undefined,

--- a/src/i18n/ru/partner.json
+++ b/src/i18n/ru/partner.json
@@ -167,7 +167,6 @@
   "partner.form.openingReceivable": "Партнёр должен нам",
   "partner.form.openingPayable": "Мы должны партнёру",
   "partner.form.openingAmount": "Сумма",
-  "partner.form.openingHint": "«−» — партнёр должен нам, «+» — мы должны партнёру.",
   "partner.form.openingPreview": "Стартовая запись в книге:",
   "partner.form.openingLockedTitle": "Начальный баланс",
   "partner.form.openingLockedSub": "Записан {{date}} — изменить нельзя",

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -1,5 +1,9 @@
 import { TransactionType } from "./transaction";
 
+// `Unit` duplicates `Piece`; removed from the product picker + default (2026-07-16).
+// Kept in the type because the backend still serves it for legacy products — the
+// migration to `Piece` is tracked in issues-tracker §12, and the edit form normalizes
+// a served `Unit` to `Piece` (see `mapProductToFormPayload`).
 export const PRODUCT_MEASUREMENTS = [
 	"Gram",
 	"Kilogram",

--- a/src/schemas/ProductSchema.ts
+++ b/src/schemas/ProductSchema.ts
@@ -1,7 +1,7 @@
 import i18next from "i18n/config";
 import { z } from "zod";
 
-export const MEASUREMENTS = ["Gram", "Kilogram", "Ton", "Piece", "Box", "Unit", "None"] as const;
+export const MEASUREMENTS = ["Gram", "Kilogram", "Ton", "Piece", "Box", "None"] as const;
 export type Measurement = (typeof MEASUREMENTS)[number];
 
 export const PRODUCT_TYPES = ["All", "Sale", "Supply"] as const;

--- a/src/utils/productUtils.ts
+++ b/src/utils/productUtils.ts
@@ -9,6 +9,8 @@ export const MEASUREMENT_SHORT: Record<Measurement, string> = {
 	Ton: "т",
 	Piece: "шт",
 	Box: "кор",
+	// Legacy alias of Piece — kept so products the backend still serves as `Unit`
+	// render a short code (issues-tracker §12); not offered in the product picker.
 	Unit: "ед",
 	None: "—",
 };
@@ -69,7 +71,10 @@ export const mapProductToFormPayload = (product: Product): ProductFormInputs => 
 	return {
 		name: product.name,
 		categoryId: product.categoryId,
-		measurement: product.measurement,
+		// `Unit` is a deprecated alias of `Piece` (removed from the picker); a product
+		// served with legacy `Unit` prefills as `Piece` so the select isn't blank and it
+		// migrates to `Piece` on save (issues-tracker §12).
+		measurement: product.measurement === "Unit" ? "Piece" : product.measurement,
 		type: product.type,
 		sku: product.sku,
 		description: product.description ?? "",


### PR DESCRIPTION
Two small UX cleanups:

- **Drop the `Unit` product measurement** (duplicate of `Piece`): removed from the picker + validation; the form default is now `Piece`. `Unit` stays valid for displaying legacy products the backend still serves, and a legacy `Unit` product normalizes to `Piece` when edited (gentle migration on save). Backend migration + enum removal tracked in `issues-tracker.md` §12.
- **Remove the redundant opening-balance sign hint** from the partner form — the «Тип остатка» selector (Партнёр должен нам / Мы должны партнёру) already states the direction.

Also carries `1e93d2a update testing docs` (the `docs/testing/` runbook, already on the branch).

Live-verified on :3000: product create dropdown excludes «Единица» (default «Штука»); legacy `Unit` products still render «Единица»; partner modal shows the type selector with no hint. `npm run validate` clean.