### PR TITLE
Fix create-line quantity clear/re-entry (POS + New Order)

### DIFF
--- a/src/components/order/Create/OrderLineRow.tsx
+++ b/src/components/order/Create/OrderLineRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CartItem, stockAt } from "hooks/transactions/useTransactionEntry";
 import { designTokens, numericSx } from "theme";
@@ -75,7 +75,22 @@ export const OrderLineRow: React.FC<OrderLineRowProps> = ({
 	const stock = stockAt(item.product, warehouseId);
 	const over = warehouseId != null && item.quantity > stock;
 
-	const setQty = (next: number) => onChange({ quantity: Math.max(1, next) });
+	// Free-form editing buffer for the quantity (mirrors CartLineRow): the field can
+	// go empty while retyping (clear «32» → type «55») instead of snapping to the min
+	// on each keystroke; only a valid value (≥ 1) commits, blur/stepper revert.
+	const [qtyDraft, setQtyDraft] = useState<string | null>(null);
+	const qtyValue = qtyDraft ?? String(item.quantity);
+	const setQty = (next: number) => {
+		setQtyDraft(null);
+		onChange({ quantity: Math.max(1, next) });
+	};
+	const onQtyChange = (raw: string) => {
+		setQtyDraft(raw);
+		const n = parseInt(raw.replace(/[^\d]/g, ""), 10);
+		if (!Number.isNaN(n) && n >= 1) {
+			onChange({ quantity: n });
+		}
+	};
 
 	return (
 		<Box
@@ -152,8 +167,10 @@ export const OrderLineRow: React.FC<OrderLineRowProps> = ({
 							<RemoveIcon sx={{ fontSize: 16 }} />
 						</IconButton>
 						<InputBase
-							value={item.quantity}
-							onChange={(e) => setQty(parseNum(e.target.value))}
+							value={qtyValue}
+							onFocus={(e) => e.currentTarget.select()}
+							onChange={(e) => onQtyChange(e.target.value)}
+							onBlur={() => setQtyDraft(null)}
 							sx={{
 								width: 44,
 								height: 36,

--- a/src/components/transaction/Create/CartLineRow.tsx
+++ b/src/components/transaction/Create/CartLineRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CartItem, stockAt } from "hooks/transactions/useTransactionEntry";
 import { designTokens, numericSx } from "theme";
@@ -91,6 +91,15 @@ export const CartLineRow: React.FC<CartLineRowProps> = ({
 	const invalid = over;
 
 	const qtyRef = useRef<HTMLInputElement>(null);
+
+	// Free-form editing buffer for the quantity: lets the field go empty while
+	// retyping (clear «32» → type «55») instead of snapping back to the min on
+	// every keystroke. Only a valid value (≥ 1) commits; blur and the stepper
+	// revert the buffer to the controlled value. Focus selects all so a
+	// click-then-type replaces too.
+	const [qtyDraft, setQtyDraft] = useState<string | null>(null);
+	const qtyValue = qtyDraft ?? String(item.quantity);
+
 	useEffect(() => {
 		if (autoFocusQty && qtyRef.current) {
 			qtyRef.current.focus();
@@ -99,7 +108,17 @@ export const CartLineRow: React.FC<CartLineRowProps> = ({
 		}
 	}, [autoFocusQty, onAutoFocused]);
 
-	const setQty = (next: number) => onChange({ quantity: Math.max(1, next) });
+	const setQty = (next: number) => {
+		setQtyDraft(null);
+		onChange({ quantity: Math.max(1, next) });
+	};
+	const onQtyChange = (raw: string) => {
+		setQtyDraft(raw);
+		const n = parseInt(raw.replace(/[^\d]/g, ""), 10);
+		if (!Number.isNaN(n) && n >= 1) {
+			onChange({ quantity: n });
+		}
+	};
 	const onQtyKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === "ArrowUp") {
 			e.preventDefault();
@@ -198,8 +217,10 @@ export const CartLineRow: React.FC<CartLineRowProps> = ({
 						</IconButton>
 						<InputBase
 							inputRef={qtyRef}
-							value={item.quantity}
-							onChange={(e) => setQty(parseNum(e.target.value))}
+							value={qtyValue}
+							onFocus={(e) => e.currentTarget.select()}
+							onChange={(e) => onQtyChange(e.target.value)}
+							onBlur={() => setQtyDraft(null)}
 							onKeyDown={onQtyKeyDown}
 							sx={{
 								width: 44,


### PR DESCRIPTION
The cart/order line quantity clamped to `Math.max(1, …)` on every keystroke, so clearing the field snapped it back to **1** and the re-render dropped the selection — the next digit appended to `1`. Changing «32» to «55» meant typing «5», deleting «1», typing «5» again.

**Fix:** a free-form editing buffer — the field can go empty while retyping, only a valid value (≥ 1) commits, and blur/stepper revert to the controlled value. Focus now **selects all**, so click-then-type also replaces.

Applied to both **CartLineRow** (POS New Sale/Supply) and **OrderLineRow** (New Order).

Live-verified in the POS on :3000: clear → `""` (not `1`); type `5`→`55`; blur reverts to the last value; focus selects all. `npm run validate` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantity editing in order and transaction forms.
  * Users can now clear or partially edit quantity fields without unwanted immediate updates.
  * Quantity changes are applied only when valid, and fields revert to the saved value when editing is canceled or loses focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->