### PR TITLE
POS polish: drop submit immutability note + align warehouse dropdown height

### DIFF
--- a/src/components/transaction/Create/TransactionSummaryCard.tsx
+++ b/src/components/transaction/Create/TransactionSummaryCard.tsx
@@ -10,7 +10,6 @@ import { formatEntityId } from "utils/formatEntityId";
 import BalanceOutlinedIcon from "@mui/icons-material/BalanceOutlined";
 import CheckIcon from "@mui/icons-material/Check";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import NorthEastIcon from "@mui/icons-material/NorthEast";
 import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import { Avatar, Box, ButtonBase, InputBase, Typography } from "@mui/material";
@@ -512,22 +511,6 @@ export const TransactionSummaryCard: React.FC<TransactionSummaryCardProps> = ({
 						})}
 					</Box>
 				)}
-				<Box
-					sx={{
-						display: "flex",
-						alignItems: "center",
-						gap: "8px",
-						p: "7px 10px",
-						borderRadius: "6px",
-						bgcolor: designTokens.infoBg,
-						fontSize: 11.5,
-						color: "text.secondary",
-						lineHeight: 1.35,
-					}}
-				>
-					<InfoOutlinedIcon sx={{ fontSize: 14, color: "info.main", flex: "0 0 auto" }} />
-					{t(`transaction.new.submit.immutable.${direction}`)}
-				</Box>
 				<PrimaryButton
 					icon={<CheckIcon />}
 					onClick={onSubmit}

--- a/src/components/transaction/Create/WarehousePicker.tsx
+++ b/src/components/transaction/Create/WarehousePicker.tsx
@@ -23,9 +23,9 @@ export const WarehousePicker: React.FC<WarehousePickerProps> = ({
 		displayEmpty
 		fullWidth
 		sx={{
-			// Match the partner Autocomplete's height (the Select's default medium
-			// padding makes it taller than the field beside it).
-			"&.MuiOutlinedInput-root": { height: 45 },
+			// Match the partner Autocomplete's height (38px) — the Select's default
+			// padding otherwise makes it taller than the field beside it.
+			"&.MuiOutlinedInput-root": { height: 38 },
 			"& .MuiSelect-select": { display: "flex", alignItems: "center" },
 		}}
 		renderValue={(v) => {

--- a/src/i18n/ru/transaction.json
+++ b/src/i18n/ru/transaction.json
@@ -295,8 +295,6 @@
   "transaction.new.pay.overBalance": "Доступно только {{available}} UZS — нельзя списать больше остатка кассы.",
 
   "transaction.new.submit.fixQty": "Исправьте количество в выделенных позициях",
-  "transaction.new.submit.immutable.Sale": "Продажа записывается окончательно — изменить нельзя, только оформить возврат.",
-  "transaction.new.submit.immutable.Supply": "Поставка записывается окончательно — изменить нельзя, только оформить возврат.",
   "transaction.new.submit.button.Sale": "Провести продажу",
   "transaction.new.submit.button.Supply": "Провести поставку",
 


### PR DESCRIPTION
Two small POS cleanups:

- **Remove the submit immutability note** — the «… записывается окончательно — изменить нельзя, только оформить возврат» info line above the submit button added noise without value. Removed for both Sale and Supply, plus the two now-dead i18n keys.
- **Match the warehouse dropdown height to the partner picker** — the warehouse `Select` was hard-coded to 45px while the partner `Autocomplete` renders at 38px; aligned to 38px.

Live-verified on :3000: note absent (submit button intact); both header pickers measure 38px. `npm run validate` clean.